### PR TITLE
fix: OONIDevopsPolicy update

### DIFF
--- a/tf/modules/adm_iam_roles/main.tf
+++ b/tf/modules/adm_iam_roles/main.tf
@@ -25,7 +25,7 @@ resource "aws_iam_policy" "oonidevops" {
         "ecr:*",
         "ecr-public:*",
         "rds:*",
-        "vpc:*",
+        "vpc-lattice:*",
         "appmesh:*",
         "autoscaling:*",
         "application-autoscaling:*",


### PR DESCRIPTION
Closes #19. This changes the `vpc:*` permissions to `vpc-lattice:*`