### PR TITLE
fix: allow ecs tagging for `ooniapi-ecs-cluster-container-host-role`

### DIFF
--- a/tf/modules/ecs_cluster/templates/profile_policy.json
+++ b/tf/modules/ecs_cluster/templates/profile_policy.json
@@ -7,6 +7,8 @@
       "Action": [
         "ec2:DescribeTags",
         "ecs:CreateCluster",
+        "ecs:TagResource",
+				"ecs:UntagResource",
         "ecs:DeregisterContainerInstance",
         "ecs:DiscoverPollEndpoint",
         "ecs:Poll",


### PR DESCRIPTION
This updates the `ooniapi-ecs-cluster-instance-role-policy` to allow ecs-tagging which is now mandated by AWS