### PR TITLE
feat: create new oonith ecs_cluster

### DIFF
--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -227,18 +227,16 @@ resource "aws_s3_bucket" "oonith_codepipeline_bucket" {
 # PENDING. Authentication with the connection provider must be completed in the
 # AWS Console.
 # See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codestarconnections_connection 
-resource "aws_codestarconnections_connection" "ooniapi" {
+resource "aws_codestarconnections_connection" "oonidevops" {
   name          = "ooniapi"
   provider_type = "GitHub"
 
   depends_on = [module.adm_iam_roles]
 }
 
-resource "aws_codestarconnections_connection" "oonith" {
-  name          = "oonith"
-  provider_type = "GitHub"
-
-  depends_on = [module.adm_iam_roles]
+moved {
+  from = aws_codestarconnections_connection.ooniapi
+  to = aws_codestarconnections_connection.oonidevops
 }
 
 ### OONI Tier0 Backend Proxy
@@ -311,7 +309,7 @@ module "ooniapi_oonirun_deployer" {
   repo                    = "ooni/backend"
   branch_name             = "master"
   buildspec_path          = "ooniapi/services/oonirun/buildspec.yml"
-  codestar_connection_arn = aws_codestarconnections_connection.ooniapi.arn
+  codestar_connection_arn = aws_codestarconnections_connection.oonidevops.arn
 
   codepipeline_bucket = aws_s3_bucket.ooniapi_codepipeline_bucket.bucket
 
@@ -357,7 +355,7 @@ module "ooniapi_ooniauth_deployer" {
   repo                    = "ooni/backend"
   branch_name             = "master"
   buildspec_path          = "ooniapi/services/ooniauth/buildspec.yml"
-  codestar_connection_arn = aws_codestarconnections_connection.ooniapi.arn
+  codestar_connection_arn = aws_codestarconnections_connection.oonidevops.arn
 
   codepipeline_bucket = aws_s3_bucket.ooniapi_codepipeline_bucket.bucket
 

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -219,12 +219,23 @@ resource "aws_s3_bucket" "ooniapi_codepipeline_bucket" {
   bucket = "codepipeline-ooniapi-${var.aws_region}-${random_id.artifact_id.hex}"
 }
 
+resource "aws_s3_bucket" "oonith_codepipeline_bucket" {
+  bucket = "codepipeline-oonith-${var.aws_region}-${random_id.artifact_id.hex}"
+}
+
 # The aws_codestarconnections_connection resource is created in the state
 # PENDING. Authentication with the connection provider must be completed in the
 # AWS Console.
 # See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codestarconnections_connection 
 resource "aws_codestarconnections_connection" "ooniapi" {
   name          = "ooniapi"
+  provider_type = "GitHub"
+
+  depends_on = [module.adm_iam_roles]
+}
+
+resource "aws_codestarconnections_connection" "oonith" {
+  name          = "oonith"
   provider_type = "GitHub"
 
   depends_on = [module.adm_iam_roles]

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -423,14 +423,3 @@ module "ooniapi_frontend" {
     { Name = "ooni-tier0-api-frontend" }
   )
 }
-
-#### OONI oohelperd service
-
-module "oonith_oohelperd_deployer" {
-  source = "../../modules/oonith_service_deployer"
-}
-
-module "oonith_oohelperd" {
-  source = "../../modules/oonith_service"
-}
-

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -269,6 +269,26 @@ module "ooniapi_cluster" {
   )
 }
 
+module "oonith_cluster" {
+  source = "../../modules/ecs_cluster"
+
+  name = "oonith-ecs-cluster"
+  key_name = module.adm_iam_roles.oonidevops_key_name
+  vpc_id = modules.network.vpc_id
+  subnet_ids = module.network.vpc_subnet[*].id
+
+  asg_min = 2
+  asg_max = 6
+  asg_desired = 2
+
+  instance_type = "t2.small"
+
+  tags = merge(
+    local.tags,
+    { Name = "ooni-tier0-th-ecs-cluster" }
+  )
+}
+
 #### OONI Tier0
 
 #### OONI Run service
@@ -378,7 +398,8 @@ module "ooniapi_ooniauth" {
     { Name = "ooni-tier0-ooniauth" }
   )
 }
-### OONI Tier0 API Frontend
+
+#### OONI Tier0 API Frontend
 
 module "ooniapi_frontend" {
   source = "../../modules/ooniapi_frontend"
@@ -402,3 +423,14 @@ module "ooniapi_frontend" {
     { Name = "ooni-tier0-api-frontend" }
   )
 }
+
+#### OONI oohelperd service
+
+module "oonith_oohelperd_deployer" {
+  source = "../../modules/oonith_service_deployer"
+}
+
+module "oonith_oohelperd" {
+  source = "../../modules/oonith_service"
+}
+

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -285,7 +285,7 @@ module "oonith_cluster" {
 
   name = "oonith-ecs-cluster"
   key_name = module.adm_iam_roles.oonidevops_key_name
-  vpc_id = modules.network.vpc_id
+  vpc_id = module.network.vpc_id
   subnet_ids = module.network.vpc_subnet[*].id
 
   asg_min = 2


### PR DESCRIPTION
This diff creates a new AWS ecs cluster (`oonith-ecs-cluster`) using the `ecs_cluster` module 

Part of #29 