### PR TITLE
Move prometheus configuration to ooni/devops

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -8,7 +8,7 @@ pyenv activate ooni-devops
 
 Install deps:
 ```
-pip install ansible dnspython
+pip install ansible dnspython boto3
 ```
 
 Run playbook:

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,3 +1,17 @@
 ### Quickstart
 
-- Install [ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+It's recommended to make use of a virtualenv, for example managed using `pyenv virtualenv`:
+```
+pyenv virtualenv ooni-devops
+pyenv activate ooni-devops
+```
+
+Install deps:
+```
+pip install ansible dnspython
+```
+
+Run playbook:
+```
+ansible-playbook playbook.yml -i inventory
+```

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -1,0 +1,2 @@
+[all]
+monitoring.ooni.org

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -6,10 +6,14 @@
   vars:
     clickhouse_reader_password: "{{ lookup('env', 'CLICKHOUSE_READER_PASSWORD') }}"
   roles:
-  - clickhouse
+    - clickhouse
   handlers:
     - name: restart clickhouse-server
       service:
         name: clickhouse-server
         state: restarted
 
+- name: Update monitoring config
+  hosts: monitoring.ooni.org
+  roles:
+    - prometheus

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -17,3 +17,5 @@
   hosts: monitoring.ooni.org
   roles:
     - prometheus
+    - prometheus_blackbox_exporter
+    - prometheus_alertmanager

--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -1,0 +1,4 @@
+prometheus_ssl_dir: /etc/prometheus/ssl
+prometheus_exporter_cert: "/etc/prometheus/exporter_ca.cert"
+prometheus_basic_auth_user: "prometheus"
+prometheus_basic_auth_password: "{{ CHANGE_ME }}"

--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -1,4 +1,2 @@
 prometheus_ssl_dir: /etc/prometheus/ssl
 prometheus_exporter_cert: "/etc/prometheus/exporter_ca.cert"
-prometheus_basic_auth_user: "prometheus"
-prometheus_basic_auth_password: "{{ CHANGE_ME }}"

--- a/ansible/roles/prometheus/files/alert_ooni.yml
+++ b/ansible/roles/prometheus/files/alert_ooni.yml
@@ -1,0 +1,30 @@
+---
+groups:
+- name: OONI Alerts
+  rules:
+  - alert: NASBackupSilent
+    expr: time() - push_time_seconds{exported_instance="hellais-nas"} > 48 * 3600
+    annotations:
+      summary: 'hellais-nas is silent for {{ $value | humanizeDuration }}'
+
+  - alert: NASRsyncFailure
+    expr: rsync_returncode{exported_instance="hellais-nas"} != 0
+    for: 48h # rsync is launched at 08:00 and 22:00, that's 14h and 10h gap
+    annotations:
+      summary: 'hellais-nas `rsync` exitcode: {{ $value }}'
+
+  # Some nodes may have it broken, but it usually works, here is expr to validate it.
+  # expr: (max without (device) (node_seeksample_timestamp{job="node"}) or up{job="node"}) == 1
+  - alert: DiskStuck
+    expr: node_time - ignoring(device) group_right node_seeksample_timestamp > 240
+    annotations:
+      summary: '{{ $labels.instance }} has `{{ $labels.device }}` silent for {{ $value | humanizeDuration }}'
+
+  - alert: MirrorDiverged
+    expr: scalar(max(ooni_web_mtime)) - ooni_web_mtime > 0
+    for: 11m # job_name=ooni-web scrape_interval is 5m, 8m10s is still "ordinary" delay
+    annotations:
+      summary: 'Mirror {{ $labels.instance }} lags by {{ $value | humanizeDuration }}'
+      description: '{{ if eq $labels.instance "ooni.torproject.org:443" }}Run `make update-site`.{{ end }}'
+
+...

--- a/ansible/roles/prometheus/files/alert_rules.yml
+++ b/ansible/roles/prometheus/files/alert_rules.yml
@@ -1,0 +1,142 @@
+---
+groups:
+- name: Basic prometheus
+  rules:
+  # node_timex_sync_status is not enabled right now as old NTP daemons do not update `timex`
+  - alert: NTPOutOfSync
+    expr: (node_scrape_collector_success{collector="ntp"} != 1) or (node_ntp_sanity != 1) # or (node_timex_sync_status != 1)
+    for: 1h
+
+  # including http scraping failure
+  - alert: InstanceDown
+    expr: up != 1
+    for: 5m
+    annotations:
+      summary: '{{ $labels.instance }} is not `up`'
+
+  - alert: systemd # yes, just "systemd", it's unclear what's going wrong :-)
+    expr: node_systemd_system_running != 1 # that's basically output of `systemctl is-system-running`
+    annotations:
+      summary: '{{ $labels.instance }} is not OK, check `systemctl list-units | grep failed`'
+
+  # the difference between node_disk_{io,read,write}_time_ms is not clear, `io` is NOT `read + write`, it may be greater, it may be less...
+  # All the nodes have `node_disk_io_time_ms`, but it can be verified with expr: (sum without(device) (node_disk_io_time_ms{job="node"}) or up{job="node"}) == 1
+  - alert: IOHigh
+    expr: irate(node_disk_io_time_ms{device!~"(nbd[0-9]+|dm-[0-9]+|ram[0-9]+|sr[0-9]+|md[0-9]+)"}[1m]) > 800
+    for: 2h
+    annotations:
+      summary: '{{ $labels.instance }}/{{ $labels.device }} spends {{ $value }}ms/s in IO over 2 hours'
+
+  - alert: CPUHigh
+    expr: sum without (mode, cpu) (irate(node_cpu{mode!="idle"}[1m])) > 0.75
+    for: 8h
+    annotations:
+      summary: '{{ $labels.instance }} has {{ printf "%.2f" $value }} of CPU core used over 8 hours'
+
+  - alert: NetworkRXHigh
+    expr: irate(node_network_receive_bytes{device!~"(docker0|veth[0-9a-f]{7}|lo|br[-a-z].*|dummy0)"}[1m]) * 8 > 50 * 1024 * 1024 # OONITestHelper has BandwidthRate 20MBits
+    for: 1h
+    annotations:
+      summary: '{{ $labels.instance }}/{{ $labels.device }} gets {{ $value | humanize }}bit/s'
+
+  - alert: NetworkTXHigh
+    expr: irate(node_network_transmit_bytes{device!~"(docker0|veth[0-9a-f]{7}|lo|br[-a-z].*|dummy0)"}[1m]) * 8 > 50 * 1024 * 1024 # OONITestHelper has BandwidthRate 20MBits
+    for: 1h
+    annotations:
+      summary: '{{ $labels.instance }}/{{ $labels.device }} sends {{ $value | humanize }}bit/s'
+
+  - alert: LoadAverageHigh
+    expr: node_load15 > 8 # largest node available has NCPU=4
+    for: 1h
+    annotations:
+      summary: '{{ $labels.instance }} has LA15 {{ printf "%.1f" $value }}'
+
+  # Old nodes: (node_vmstat_oom_kill or (-node_time)) < 0
+  - alert: OOM
+    expr: round(rate(node_vmstat_oom_kill[5m]) * 300, 1) > 0
+    annotations:
+      summary: '{{ $labels.instance }} had {{ $value }} OOMs in 5m'
+
+  - alert: NodeSwapping
+    expr: rate(node_vmstat_pgmajfault[1m]) > 100 # and instance:node_memory_available:ratio < 0.05
+    for: 15m # number stolen from https://dev.gitlab.org/cookbooks/runbooks/blob/master/rules/node.yml
+    labels: {severity: info}
+    annotations:
+      summary: '{{ $labels.instance }} has {{ printf "%.1f" $value }} pagefaults/second.'
+
+  # NB: node_filesystem_avail is for non-root users, node_filesystem_free is for root. They are equal for XFS.
+  - alert: DiskWillFillInAWeek
+    expr: 8 * node_filesystem_avail - 7 * (node_filesystem_avail offset 1d) < 0 # x75 speedup of (node_filesystem_avail + delta(node_filesystem_avail[24h])*7) < 0
+    for: 1h
+    annotations:
+      summary: '{{ $labels.instance }} becomes /dev/full soon'
+      # NB: it looks strange, but having labels for EVERY series improves query latency
+      description: >
+        In {{ (printf "node_filesystem_avail{instance='%s',mountpoint='%s'} / ((node_filesystem_avail{instance='%s',mountpoint='%s'} offset 1d) - node_filesystem_avail{instance='%s',mountpoint='%s'}) * 86400" $labels.instance $labels.mountpoint $labels.instance $labels.mountpoint $labels.instance $labels.mountpoint) | query | first | value | humanizeDuration }}
+        `{{ $labels.mountpoint }}` will be full.
+        {{ (printf "node_filesystem_avail{instance='%s',mountpoint='%s'}" $labels.instance $labels.mountpoint) | query | first | value | humanize1024 }}B available,
+        {{ (printf "(node_filesystem_avail{instance='%s',mountpoint='%s'} offset 1d) - node_filesystem_avail{instance='%s',mountpoint='%s'}" $labels.instance $labels.mountpoint $labels.instance $labels.mountpoint) | query | first | value | humanize1024 }}B/day growth.
+
+  # <10Gb and <20% available. Make some sense for huge storages and small ramdrives.
+  - alert: DiskFull
+    expr: (node_filesystem_avail < 10737418240) and (node_filesystem_avail / node_filesystem_size * 100 < 20)
+    annotations:
+      summary: '{{ $labels.instance }}{{ $labels.mountpoint }} is almost full'
+      description: >
+        {{ $value | humanize1024 }}B
+        ~ {{ (printf "round(node_filesystem_avail{instance='%s',mountpoint='%s'} / node_filesystem_size * 100)" $labels.instance $labels.mountpoint) | query | first | value }}%
+        available at {{ $labels.instance }}{{ $labels.mountpoint }}.
+
+  - alert: DiskInodesOver50pct
+    expr: node_filesystem_files_free / node_filesystem_files * 100 < 50
+    annotations:
+      summary: '`df -i` at {{ $labels.instance }} over 50%'
+      description: '{{ printf "%.1f" $value }}% inodes available at {{ $labels.mountpoint }}.'
+
+  # sub-scraping failure
+  - alert: TextfileError
+    expr: node_textfile_scrape_error > 0
+    annotations:
+      summary: 'Broken `textfile` at {{ $labels.instance }}'
+
+  # all the textfile are updated at least hourly
+  - alert: TextfileJam
+    expr: (node_textfile_mtime - ON(instance,job) GROUP_LEFT() node_time) / -3600 > 2
+    annotations:
+      summary: 'Stale `textfile` at {{ $labels.instance }}'
+      description: '`{{ $labels.file }}` is {{ printf "%.0f" $value }}h old.'
+
+  # naive prometheus health monitoring
+  - alert: ScrapeSamplesLoss
+    expr: sum(scrape_samples_scraped) / sum(scrape_samples_scraped offset 24h) < 0.5
+    annotations:
+      summary: Lots of `scrape_samples_scraped` lost
+      description: Now ~ {{ "sum(scrape_samples_scraped)" | query | first | value | humanize }}, 24h ago ~ {{ "sum(scrape_samples_scraped offset 24h)" | query | first | value | humanize }}.
+
+  # to make the onion service alerts less noisy, we will alert only when the
+  # onion jobs are down for 60 minutes instead of 10.
+  - alert: BlackboxDown
+    expr: probe_success{job=~"onion .+"} == 0
+    for: 60m
+    annotations:
+      summary: "{{ $labels.instance }} endpoint down"
+
+  - alert: BlackboxDown
+    expr: probe_success{job!~"onion .+"} == 0
+    for: 10m
+    annotations:
+      summary: "{{ $labels.instance }} endpoint down"
+
+  - alert: SSLCertExpires
+    expr: (probe_ssl_earliest_cert_expiry{job!="tor testhelper"} - time()) / 25200 < 25
+    annotations:
+      summary: '`certbot` failed at {{ $labels.instance }}'
+      description: 'SSL cert for  expires in {{ printf "%.0f" $value }} days.'
+
+- name: Prometheus self-care
+  rules:
+  - alert: AlertmanagerNotificationsFailing
+    expr: rate(alertmanager_notifications_failed_total[1m]) > 0
+    annotations:
+      summary: 'Alertmanager {{ $labels.instance }} fails {{ $labels.integration }} notifications.'
+...

--- a/ansible/roles/prometheus/handlers/main.yml
+++ b/ansible/roles/prometheus/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: restart prometheus
+  systemd: name=prometheus.service state=restarted
+
+- name: reload prometheus
+  systemd: name=prometheus.service state=reloaded

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: lookup prometheus scraping username
+  debug:
+    msg: "{{ lookup('amazon.aws.aws_secret', 'oonidevops/ooni_services/prometheus_metrics_password	', bypath=true) }}"
+
 - name: Configure rules files
   copy:
     src: "{{ item }}"

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: lookup prometheus scraping username
-  debug:
-    msg: "{{ lookup('amazon.aws.aws_secret', 'oonidevops/ooni_services/prometheus_metrics_password	', bypath=true) }}"
-
 - name: Configure rules files
   copy:
     src: "{{ item }}"

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -11,7 +11,7 @@
     - "alert_*.yml"
   notify:
     - reload prometheus
-  tags: prometheus-conf
+  tags: prometheus
 
 - name: Configure Prometheus
   template:
@@ -23,4 +23,6 @@
     validate: "/usr/bin/promtool check config %s"
   notify:
     - reload prometheus
-  tags: prometheus-conf
+  tags: prometheus
+  vars:
+    prometheus_metrics_password: "{{ lookup('amazon.aws.aws_secret', 'oonidevops/ooni_services/prometheus_metrics_password') }}"

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Configure rules files
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/prometheus/"
+    owner: root
+    group: root
+    mode: 0644
+    validate: "/usr/bin/promtool check rules %s"
+  with_fileglob:
+    - "alert_*.yml"
+  notify:
+    - reload prometheus
+  tags: prometheus-conf
+
+- name: Configure Prometheus
+  template:
+    src: prometheus.yml
+    dest: "/etc/prometheus/prometheus.yml"
+    owner: root
+    group: root
+    mode: 0644
+    validate: "/usr/bin/promtool check config %s"
+  notify:
+    - reload prometheus
+  tags: prometheus-conf

--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -1,0 +1,139 @@
+---
+global:
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  scrape_timeout:      15s
+
+# the path is absolute as ansible `validates` temporary file in some temporary directory
+rule_files:
+  - "/etc/prometheus/alert_rules.yml"
+  - "/etc/prometheus/alert_ooni.yml"
+
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets: [ '127.0.0.1:9093' ]
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+
+{% for bbjob in blackbox_jobs %}
+  - job_name: "{{ bbjob.name }}"
+    metrics_path: /probe
+    params:
+      module: [{{ bbjob.module }}]
+    static_configs:
+      - targets:
+  {% for target in (bbjob.targets|sort) %}
+        - {{ target }}
+  {% endfor %}
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: (.*)(:80)?
+        target_label: __param_target
+        replacement: ${1}
+      - source_labels: [__param_target]
+        regex: (.*)
+        target_label: instance
+        replacement: ${1}
+      - source_labels: []
+        regex: .*
+        target_label: __address__
+        replacement: 127.0.0.1:9115
+{% endfor %}
+
+  - job_name: 'node'
+    scrape_interval: 5s
+    scheme: https
+    tls_config:
+      ca_file: "{{ prometheus_exporter_cert }}"
+      cert_file: "{{ prometheus_ssl_dir }}/{{ inventory_hostname }}.chain"
+      key_file: "{{ prometheus_ssl_dir }}/{{ inventory_hostname }}.key"
+      # XXX this is a hotfix to https://github.com/ooni/backend/issues/747
+      insecure_skip_verify: true
+    static_configs:
+      - targets:
+{% for host in (dom0_hosts|sort) %}
+        - {{ host }}:9100
+{% endfor %}
+
+#  - job_name: 'netdata'
+#    scrape_interval: 5s
+#    scheme: https
+#    metrics_path: /api/v1/allmetrics
+#    params:
+#      format: [prometheus]
+#    tls_config:
+#      ca_file: "{{ prometheus_exporter_cert }}"
+#      cert_file: "{{ prometheus_ssl_dir }}/{{ inventory_hostname }}.chain"
+#      key_file: "{{ prometheus_ssl_dir }}/{{ inventory_hostname }}.key"
+#    static_configs:
+#      - targets:
+
+  - job_name: 'raw-netdata'
+    scrape_interval: 5s
+    scheme: http
+    metrics_path: "/api/v1/allmetrics"
+    params:
+      format: [prometheus]
+    static_configs:
+      - targets:
+        - ams-pg-test.ooni.org:19999
+        - ams-pg.ooni.org:19999
+        - backend-fsn.ooni.org:19999
+        - backend-hel.ooni.org:19999
+        - 0.th.ooni.org:19999
+        - 1.th.ooni.org:19999
+        - 2.th.ooni.org:19999
+        - 3.th.ooni.org:19999
+        # - 2.th.ooni.org:19999
+
+  - job_name: 'test-helpers'
+    scrape_interval: 5s
+    scheme: http
+    metrics_path: "/metrics"
+    static_configs:
+      - targets:
+        - 0.th.ooni.org:9001
+        - 1.th.ooni.org:9001
+        - 2.th.ooni.org:9001
+        - 3.th.ooni.org:9001
+
+  - job_name: 'ooni-api'
+    scrape_interval: 5s
+    scheme: https
+    static_configs:
+      - targets: [ 'api.ooni.io:443' ]
+
+  - job_name: 'ooni-web'
+    scrape_interval: 5m
+    scheme: https
+    metrics_path: /_web.mtime.txt
+    static_configs:
+    - targets: # all mirrors listed in https://github.com/TheTorProject/ooni-web#ooni-web
+      - ooni.io:443
+      - ooni.torproject.org:443
+      - openobservatory.github.io:443
+      - ooni.netlify.com:443
+
+  - job_name: 'clickhouse'
+    scrape_interval: 5s
+    scheme: http
+    metrics_path: "/metrics"
+    static_configs:
+      - targets:
+        - backend-fsn.ooni.org:9363
+
+  # See ansible/roles/ooni-backend/tasks/main.yml for the scraping targets
+  - job_name: 'haproxy'
+    scrape_interval: 5s
+    scheme: https
+    metrics_path: "/__haproxy_prom_metrics"
+    static_configs:
+      - targets:
+        - backend-hel.ooni.org:444
+        - ams-pg-test.ooni.org:444
+
+...

--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -107,6 +107,18 @@ scrape_configs:
     static_configs:
       - targets: [ 'api.ooni.io:443' ]
 
+  - job_name: 'ooniapi-services'
+    scrape_interval: 5s
+    scheme: https
+    metrics_path: "/metrics"
+    basic_auth:
+      username: 'prom'
+      password: '{{ prometheus_metrics_password }}'
+    static_configs:
+      targets:
+        - ooniauth.api.dev.ooni.io
+        - oonirun.api.dev.ooni.io
+
   - job_name: 'ooni-web'
     scrape_interval: 5m
     scheme: https

--- a/ansible/roles/prometheus/vars/main.yml
+++ b/ansible/roles/prometheus/vars/main.yml
@@ -9,10 +9,6 @@ dom0_hosts:
   - mia-echoth.ooni.nu
   - mia-httpth.ooni.nu
 
-new_prom_metrics_hosts:
-  - ooniauth.api.dev.ooni.io
-  - oonirun.api.dev.ooni.io
-
 blackbox_jobs:
   - name: "ooni web_connectivity test helpers"
     module: "ooni_web_connectivity_ok"

--- a/ansible/roles/prometheus/vars/main.yml
+++ b/ansible/roles/prometheus/vars/main.yml
@@ -9,6 +9,10 @@ dom0_hosts:
   - mia-echoth.ooni.nu
   - mia-httpth.ooni.nu
 
+new_prom_metrics_hosts:
+  - ooniauth.api.dev.ooni.io
+  - oonirun.api.dev.ooni.io
+
 blackbox_jobs:
   - name: "ooni web_connectivity test helpers"
     module: "ooni_web_connectivity_ok"

--- a/ansible/roles/prometheus/vars/main.yml
+++ b/ansible/roles/prometheus/vars/main.yml
@@ -1,0 +1,131 @@
+dom0_hosts:
+  - ams-ps.ooni.nu
+  - ams-slack-1.ooni.org
+  - ams-wcth2.ooni.nu
+  - ams-wcth3.ooni.nu
+  - amsmatomo.ooni.nu
+  - db-1.proteus.ooni.io
+  - doams1-countly.ooni.nu
+  - mia-echoth.ooni.nu
+  - mia-httpth.ooni.nu
+
+blackbox_jobs:
+  - name: "ooni web_connectivity test helpers"
+    module: "ooni_web_connectivity_ok"
+    targets:
+      # - "https://a.web-connectivity.th.ooni.io/status"
+      - "https://wcth.ooni.io/status"
+      - "https://ams-wcth2.ooni.nu/status"
+      - "https://a.web-connectivity.th.ooni.io/status" # "https://ams-wcth3.ooni.nu/status"
+      # cloudfront
+      - "https://d33d1gs9kpq1c5.cloudfront.net/status"
+
+  - name: "new test helpers"
+    module: "new_test_helper_health"
+    targets:
+      - "https://0.th.ooni.org/"
+      - "https://1.th.ooni.org/"
+      - "https://2.th.ooni.org/"
+      - "https://3.th.ooni.org/"
+
+  - name: "ooni collector"
+    module: "ooni_collector_ok"
+    targets:
+      # - "https://a.collector.ooni.io/invalidpath"
+      - "https://b.collector.ooni.io/invalidpath" # hardcoded in MK as a fallback in case of bouncer failure
+      - "https://c.collector.ooni.io/invalidpath"
+      # cloudfront
+      - "https://dkyhjv0wpi2dk.cloudfront.net/invalidpath"
+      - "https://dvp6h0xblpcqp.cloudfront.net/invalidpath"
+      # Probe services
+      - "https://ps.ooni.io/invalidpath"
+      - "https://collector.ooni.io/invalidpath"
+
+  - name: "ooni bouncer"
+    module: "ooni_bouncer_ok"
+    targets:
+      - "https://bouncer.ooni.io/bouncer/net-tests"
+      - "https://ps.ooni.io/bouncer/net-tests"
+      # cloudfront
+      - "https://d3kr4emv7f56qa.cloudfront.net/bouncer/net-tests"
+
+  # IP addresses are used for test-helpers in monitoring configuration for some
+  # historical reason hopefully remembered by @hellais.
+  - name: "ooni tcp echo"
+    module: "ooni_tcp_echo_ok"
+    targets:
+      - "{{ lookup('dig', 'c.echo.th.ooni.io/A') }}:80"
+
+  - name: "ooni http return json headers"
+    module: "ooni_http_return_json_headers_ok"
+    targets:
+      - "http://{{ lookup('dig', 'a.http.th.ooni.io/A') }}:80"
+
+  - name: "ooni explorer homepage"
+    module: "http_2xx"
+    targets:
+      - "https://explorer.ooni.org/"
+
+  # API #
+
+  - name: "ooni API measurements"
+    module: "http_2xx"
+    targets:
+      - "https://api.ooni.io/api/v1/measurements"
+      - "https://ams-pg-test.ooni.org/api/v1/measurements"
+
+  - name: "ooni API test-list urls"
+    module: "https_2xx_json_meta"
+    targets:
+      - "https://api.ooni.io/api/v1/test-list/urls?country_code=US"
+
+  - name: "ooni API test-helpers"
+    module: "https_2xx_json"
+    targets:
+      - "https://api.ooni.io/api/v1/test-helpers"
+
+  - name: "ooni API priv global overview"
+    module: "https_2xx_json"
+    targets:
+      - "https://api.ooni.io/api/_/global_overview"
+
+  # end of API #
+
+  - name: "countly.ooni.io ping"
+    module: "http_2xx"
+    targets:
+      - "https://countly.ooni.io/o/ping"
+
+  - name: "slack inviter"
+    module: "http_2xx"
+    targets:
+      - "https://slack.ooni.org"
+
+  - name: "ooni website"
+    module: "http_2xx"
+    targets:
+      - "https://ooni.torproject.org"
+      - "https://ooni.org"
+
+  # Make sure that we can still access the .well-known/acme-challenge dir
+  # TODO(bassosimone): we should monitor all hosts here.
+  - name: "check for .well-known/acme-challenge availability"
+    module: "http_2xx"
+    targets:
+      - http://ams-pg-test.ooni.org/.well-known/acme-challenge/ooni-acme-canary
+
+  - name: "orchestrate"
+    module: "ooni_orchestrate"
+    targets: ["https://orchestrate.ooni.io:443/api/v1/test-list/urls?limit=10"]
+
+  - name: "registry"
+    module: "ooni_registry"
+    targets: ["https://registry.proteus.ooni.io:443/api/v1/register"]
+
+  - name: ssh
+    module: ssh_banner
+    targets: "{{ dom0_hosts | map('regex_replace', '$', ':22') | list }}"
+
+  - name: icmp
+    module: icmp
+    targets: "{{ dom0_hosts | list }}"

--- a/ansible/roles/prometheus_alertmanager/defaults/main.yml
+++ b/ansible/roles/prometheus_alertmanager/defaults/main.yml
@@ -1,0 +1,1 @@
+alertmanager_slack_api_url: "{{ CHANGE_ME }}"

--- a/ansible/roles/prometheus_alertmanager/files/templates/ooni.tmpl
+++ b/ansible/roles/prometheus_alertmanager/files/templates/ooni.tmpl
@@ -1,0 +1,6 @@
+{{ define "slack.ooni.text" }}{{ range $i, $el := .Alerts }}{{ if gt $i 0 }}
+{{ end }}{{ $el.Annotations.description }}{{ end }}{{ end }}
+
+{{ define "slack.ooni.title" }}
+{{ range $i, $el := .Alerts }}{{ if gt $i 0 }}
+{{ end }}{{ if eq $el.Status "resolved" }}[RESOLVED] {{ else }}[FIRING] {{ end }}{{ $el.Annotations.summary }}{{ end }}{{ end }}

--- a/ansible/roles/prometheus_alertmanager/handlers/main.yml
+++ b/ansible/roles/prometheus_alertmanager/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart alertmanager
+  systemd: name=prometheus-alertmanager.service state=restarted
+- name: reload alertmanager
+  systemd: name=prometheus-alertmanager.service state=reloaded

--- a/ansible/roles/prometheus_alertmanager/tasks/main.yml
+++ b/ansible/roles/prometheus_alertmanager/tasks/main.yml
@@ -38,4 +38,8 @@
     mode: 0644
     validate: "amtool check-config %s"
   vars:
-    alertmanager_slack_api_url: "oonidevops/prometheus/alertmanager_slack_api_url"
+    alertmanager_slack_api_url: >
+      {{ lookup(
+        'amazon.aws.aws_secret', 
+        'arn:aws:secretsmanager:eu-central-1:905418398257:secret:oonidevops/prometheus/alertmanager_slack_api_url-R8vOjb'
+      ) }}

--- a/ansible/roles/prometheus_alertmanager/tasks/main.yml
+++ b/ansible/roles/prometheus_alertmanager/tasks/main.yml
@@ -1,0 +1,41 @@
+- name: Installs packages
+  tags: monitoring, alertmanager
+  apt:
+    install_recommends: no
+    cache_valid_time: 86400
+    name:
+      - prometheus-alertmanager
+
+- name: Configure Alertmanager templates
+  tags: monitoring, alertmanager
+  notify:
+    - reload alertmanager
+  copy:
+    src: "{{ item }}"
+    dest: /etc/prometheus/alertmanager_templates/
+    owner: root
+    group: root
+    mode: 0644
+  with_fileglob:
+    - templates/*.tmpl
+
+- name: Configure Alertmanager
+  tags: monitoring, alertmanager
+  lineinfile:
+    path: /etc/default/prometheus-alertmanager
+    regexp: "^ARGS="
+    line: ARGS='--cluster.listen-address= --web.listen-address="127.0.0.1:9093"'
+
+- name: Reload Alertmanager
+  tags: monitoring, alertmanager
+  notify:
+    - reload alertmanager
+  template:
+    src: alertmanager.yml
+    dest: /etc/prometheus/alertmanager.yml
+    owner: root
+    group: root
+    mode: 0644
+    validate: "amtool check-config %s"
+  vars:
+    alertmanager_slack_api_url: "oonidevops/prometheus/alertmanager_slack_api_url"

--- a/ansible/roles/prometheus_alertmanager/tasks/main.yml
+++ b/ansible/roles/prometheus_alertmanager/tasks/main.yml
@@ -20,14 +20,14 @@
     - templates/*.tmpl
 
 - name: Configure Alertmanager
-  tags: monitoring, alertmanager
+  tags: alertmanager
   lineinfile:
     path: /etc/default/prometheus-alertmanager
     regexp: "^ARGS="
-    line: ARGS='--cluster.listen-address= --web.listen-address="127.0.0.1:9093"'
+    line: ARGS='--cluster.listen-address= --web.listen-address="127.0.0.1:9093" --web.external-url="https://grafana.ooni.org"'
 
 - name: Reload Alertmanager
-  tags: monitoring, alertmanager
+  tags: alertmanager
   notify:
     - reload alertmanager
   template:
@@ -38,8 +38,4 @@
     mode: 0644
     validate: "amtool check-config %s"
   vars:
-    alertmanager_slack_api_url: >
-      {{ lookup(
-        'amazon.aws.aws_secret', 
-        'arn:aws:secretsmanager:eu-central-1:905418398257:secret:oonidevops/prometheus/alertmanager_slack_api_url-R8vOjb'
-      ) }}
+    alertmanager_slack_api_url: "{{ lookup('amazon.aws.aws_secret', 'oonidevops/prometheus/alertmanager_slack_api_url') }}"

--- a/ansible/roles/prometheus_alertmanager/templates/alertmanager.yml
+++ b/ansible/roles/prometheus_alertmanager/templates/alertmanager.yml
@@ -1,0 +1,79 @@
+---
+# managed by ansible - see ansible/roles/alertmanager/templates/alertmanager.yml.j2
+
+global:
+  # While sending alerts directly to MX don't forget to:
+  # - whitelist IP addressess on MX SPAM filters so recepients don't drop the messages on ingress,
+  #   the instruction to do that for G Suite MX can be found at https://support.google.com/a/answer/60751?hl=en
+  #   see also `openobservatory_smtp_whitelist` variable
+  # - amend SPF records for domain name used in `smtp_from` so messages don't look fishy on egress
+  smtp_hello: {{ inventory_hostname }}
+  smtp_from: noreply+prometheus@ooni.io
+  slack_api_url: '{{ alertmanager_slack_api_url }}'
+  # The smarthost and SMTP sender used for mail notifications.
+  #smtp_smarthost: 'localhost:25'
+  #smtp_from: 'alertmanager@example.org'
+  #smtp_auth_username: 'alertmanager'
+  #smtp_auth_password: 'password'
+
+# The directory from which notification templates are read.
+templates:
+- '/etc/prometheus/alertmanager_templates/*.tmpl'
+
+# The root route on which each incoming alert enters.
+route:
+  # The labels by which incoming alerts are grouped together.
+  # Batching using `alertname` leads to over-grouping and OONI currently has no
+  # _defined_ notion of clusters and/or service, so grouping is done using
+  # `instance` tag. That sort of grouping is useful for disk-space alerts.
+  group_by: ['alertname', 'instance']
+  group_wait: 30s
+  # When the first notification was sent, wait 'group_interval' to send a batch
+  # of new alerts that started firing for that group.
+  group_interval: 5m
+
+  # If an alert has successfully been sent, wait 'repeat_interval' to
+  # resend them.
+  repeat_interval: 3h
+
+  # A default receiver
+  receiver: team-all
+
+  # All the above attributes are inherited by all child routes and can
+  # overwritten on each.
+  routes:
+  - receiver: team-email
+    repeat_interval: 24h
+    match: {severity: info}
+
+# Inhibition rules allow to mute a set of alerts given that another alert is
+# firing.
+# We use this to mute any warning-level notifications if the same alert is
+# already critical.
+inhibit_rules:
+
+{# # One may expect `min` instead of `sort|first`, but that's jinja 2.10+ and 2.8 is used now. #}
+{% set am_mx_openobservatory = (lookup('dig', 'openobservatory.org/MX', 'flat=0') | sort(attribute='preference') | first).exchange.rstrip('.').lower() %}
+
+receivers:
+- name: 'team-all'
+  email_configs:
+{% for u in ['arturo', 'simone'] %}
+  - to: '{{ u }}@openobservatory.org'
+    send_resolved: true
+    smarthost: {{ am_mx_openobservatory }}:25
+{% endfor %}
+  slack_configs:
+  - send_resolved: true
+    text: '{% raw %}{{ template "slack.ooni.text" . }}{% endraw %}'
+    title: '{% raw %}{{ template "slack.ooni.title" . }}{% endraw %}'
+    channel: '#ooni-bots'
+
+- name: 'team-email' # no slack
+  email_configs:
+{% for u in ['arturo', 'simone'] %}
+  - to: '{{ u }}@openobservatory.org'
+    send_resolved: true
+    smarthost: {{ am_mx_openobservatory }}:25
+{% endfor %}
+...

--- a/ansible/roles/prometheus_blackbox_exporter/handlers/main.yml
+++ b/ansible/roles/prometheus_blackbox_exporter/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart blackbox_exporter
+  service:
+    name: prometheus-blackbox-exporter
+    state: restarted

--- a/ansible/roles/prometheus_blackbox_exporter/tasks/main.yml
+++ b/ansible/roles/prometheus_blackbox_exporter/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: Install config file
+  template:
+    src: blackbox.yml
+    dest: "/etc/prometheus/blackbox.yml"
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart blackbox_exporter
+  tags: blackbox_exporter
+
+- name: Setcap
+  command: setcap cap_net_raw=ep /usr/bin/prometheus-blackbox-exporter
+  tags: blackbox_exporter
+  notify:
+    - restart blackbox_exporter

--- a/ansible/roles/prometheus_blackbox_exporter/templates/blackbox.yml
+++ b/ansible/roles/prometheus_blackbox_exporter/templates/blackbox.yml
@@ -1,0 +1,163 @@
+---
+# Used together with host_vars/monitoring.ooni.org/vars.yml
+modules:
+  http_2xx:
+    prober: http
+    timeout: 30s
+    http:
+      preferred_ip_protocol: ip4
+  http_post_2xx:
+    prober: http
+    timeout: 30s
+    http:
+      method: POST
+  tcp_connect:
+    prober: tcp
+    timeout: 30s
+  pop3s_banner:
+    prober: tcp
+    tcp:
+      query_response:
+      - expect: "^+OK"
+      tls: true
+      tls_config:
+        insecure_skip_verify: false
+  ssh_banner:
+    prober: tcp
+    timeout: 30s
+    tcp:
+      preferred_ip_protocol: ip4
+      query_response:
+      - expect: "^SSH-2.0-"
+        send: "SSH-2.0-blackbox_exporter OONI-prometheus-0.0\x0d" # WTF: \x0a is auto-added https://github.com/prometheus/blackbox_exporter/blob/master/tcp.go#L127
+      # FIXME: `blackbox_exporter` waits for newline, so we can't wait for handshake :-(
+      # - expect: "diffie-hellman-group14-sha1.*ssh-dss.*hmac-sha1.*hmac-sha1.*none.*none"
+  irc_banner:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      query_response:
+      - send: "NICK prober"
+      - send: "USER prober prober prober :prober"
+      - expect: "PING :([^ ]+)"
+        send: "PONG ${1}"
+      - expect: "^:[^ ]+ 001"
+  icmp:
+    prober: icmp
+    timeout: 5s
+    icmp:
+      preferred_ip_protocol: ip4
+
+  tls_snakeoil:
+    prober: tcp
+    tcp:
+      tls: true
+      tls_config:
+        insecure_skip_verify: true
+
+  # When using this prober, be sure to target:
+  # https://collector.ooni.io/invalidpath
+  ooni_collector_ok:
+    prober: http
+    http:
+      valid_status_codes: [404]
+      method: GET
+
+  # When using this prober, be sure to target:
+  # https://bouncer.ooni.io/bouncer/net-tests
+  ooni_bouncer_ok:
+    prober: http
+    http:
+      method: POST
+      headers:
+        Content-Type: application/json
+      body: '{"net-tests":[{"input-hashes":null,"name":"web_connectivity","test-helpers":["web-connectivity"],"version":"0.0.1"}]}'
+      fail_if_body_not_matches_regexp:
+      - '"web-connectivity":' # some bouncer-like response
+
+  # When using this prober, be sure to target:
+  # https://web-connectivity.th.ooni.io/status
+  ooni_web_connectivity_ok:
+    prober: http
+    http:
+      valid_status_codes: [200]
+      method: GET
+      fail_if_body_not_matches_regexp:
+        - ".+?\"status\".+?\"ok\".+?"
+
+  # Send JSON with a POST to a new test helper to run a real http_request and tcp_connect test
+  new_test_helper_health:
+    prober: http
+    timeout: 25s
+    http:
+      valid_status_codes: [200]
+      method: POST
+      headers:
+        Content-Type: application/json
+      body: '{"http_request":"https://google.com/","http_request_headers":{},"tcp_connect":["8.8.8.8:443"]}'
+      fail_if_body_not_matches_regexp:
+        - "Google"
+
+  ooni_tcp_echo_ok:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      query_response:
+        - send: "TEST"
+        - expect: "TEST"
+
+  ooni_http_return_json_headers_ok:
+    prober: http
+    http:
+      valid_status_codes: [200]
+      method: GET
+      fail_if_body_not_matches_regexp:
+        - ".+?\"headers_dict\".+?"
+
+  ooni_orchestrate:
+    prober: http
+    http:
+      fail_if_body_not_matches_regexp:
+      - "\"category_code\":"
+
+  ooni_registry:
+    prober: http
+    http:
+      valid_status_codes: [404]
+      method: GET
+      fail_if_body_not_matches_regexp:
+      - "404 page not found"
+
+  https_2xx_json:
+    http:
+      method: GET
+      valid_status_codes: []  # Defaults to 2xx
+      fail_if_not_ssl: true
+      preferred_ip_protocol: "ip4" # defaults to "ip6"
+      ip_protocol_fallback: false  # no fallback to "ip6"
+      headers:
+        User-Agent: ooni blackbox
+      no_follow_redirects: false
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      fail_if_body_not_matches_regexp:
+        - "}"
+    prober: http
+    timeout: 30s
+
+  https_2xx_json_meta:
+    http:
+      method: GET
+      valid_status_codes: []  # Defaults to 2xx
+      fail_if_not_ssl: true
+      preferred_ip_protocol: "ip4" # defaults to "ip6"
+      ip_protocol_fallback: false  # no fallback to "ip6"
+      headers:
+        User-Agent: ooni blackbox
+      no_follow_redirects: false
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      fail_if_body_not_matches_regexp:
+        - "metadata"
+    prober: http
+    timeout: 30s
+
+...


### PR DESCRIPTION
In this PR we move the prometheus configuration from ooni/sysadmin into ooni/devops.

As part of this work I also deleted pieces of the original configuration that were effectively dead code.

Going forward we should only deploy changes to the monitoring configuration from ooni/devops and we should update the developer docs where relevant.

As an interim safety running the playbook for monitoring will display a warning message and not run in ooni/sysadmin: https://github.com/ooni/sysadmin/pull/519.