### PR TITLE
Add DNS records for OONI test helpers

### DIFF
--- a/.github/workflows/check_terraform.yml
+++ b/.github/workflows/check_terraform.yml
@@ -39,7 +39,7 @@ jobs:
           aws_access_key_id = ${{ secrets.OONIDEVOPS_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key = ${{ secrets.OONIDEVOPS_AWS_SECRET_ACCESS_KEY }}
 
-          [oonidevops_user]
+          [oonidevops_user_dev]
           aws_access_key_id = ${{ secrets.OONIDEVOPS_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key = ${{ secrets.OONIDEVOPS_AWS_SECRET_ACCESS_KEY }}
           EOF

--- a/tf/environments/prod/dns_records.tf
+++ b/tf/environments/prod/dns_records.tf
@@ -1005,3 +1005,70 @@ resource "aws_route53_record" "test-ooni-nu-_NS_" {
   type                             = "NS"
   zone_id                          = local.dns_root_zone_ooni_nu
 }
+
+## Records for the th.ooni.org zone
+
+
+resource "aws_route53_record" "_3-th-ooni-org-_AAAA_" {
+  name                             = "3.th.ooni.org"
+  records                          = ["2604:a880:4:1d0::69e:f000"]
+  ttl                              = "60"
+  type                             = "AAAA"
+  zone_id                          = local.dns_root_zone_ooni_org
+}
+
+resource "aws_route53_record" "_3-th-ooni-org-_A_" {
+  name                             = "3.th.ooni.org"
+  records                          = ["146.190.119.3"]
+  ttl                              = "60"
+  type                             = "A"
+  zone_id                          = local.dns_root_zone_ooni_org
+}
+
+resource "aws_route53_record" "_2-th-ooni-org-_A_" {
+  name                             = "2.th.ooni.org"
+  records                          = ["161.35.89.250"]
+  ttl                              = "60"
+  type                             = "A"
+  zone_id                          = local.dns_root_zone_ooni_org
+}
+
+resource "aws_route53_record" "_2-th-ooni-org-_AAAA_" {
+  name                             = "2.th.ooni.org"
+  records                          = ["2a03:b0c0:2:d0::1768:9001"]
+  ttl                              = "60"
+  type                             = "AAAA"
+  zone_id                          = local.dns_root_zone_ooni_org
+}
+
+resource "aws_route53_record" "_1-th-ooni-org-_A_" {
+  name                             = "1.th.ooni.org"
+  records                          = ["161.35.89.250"]
+  ttl                              = "60"
+  type                             = "A"
+  zone_id                          = local.dns_root_zone_ooni_org
+}
+
+resource "aws_route53_record" "_1-th-ooni-org-_AAAA_" {
+  name                             = "1.th.ooni.org"
+  records                          = ["2a03:b0c0:2:d0::1768:9001"]
+  ttl                              = "60"
+  type                             = "AAAA"
+  zone_id                          = local.dns_root_zone_ooni_org
+}
+
+resource "aws_route53_record" "_0-th-ooni-org-_A_" {
+  name                             = "0.th.ooni.org"
+  records                          = ["146.190.119.3"]
+  ttl                              = "60"
+  type                             = "A"
+  zone_id                          = local.dns_root_zone_ooni_org
+}
+
+resource "aws_route53_record" "_0-th-ooni-org-_AAAA_" {
+  name                             = "0.th.ooni.org"
+  records                          = ["2604:a880:4:1d0::69e:f000"]
+  ttl                              = "60"
+  type                             = "AAAA"
+  zone_id                          = local.dns_root_zone_ooni_org
+}

--- a/tf/environments/prod/dns_records.tf
+++ b/tf/environments/prod/dns_records.tf
@@ -366,14 +366,6 @@ resource "aws_route53_record" "test-lists-test-ooni-org-_CNAME_" {
   zone_id                          = local.dns_root_zone_ooni_org
 }
 
-resource "aws_route53_record" "th-ooni-org-_NS_" {
-  name                             = "th.ooni.org"
-  records                          = ["ns1.digitalocean.com"]
-  ttl                              = "300"
-  type                             = "NS"
-  zone_id                          = local.dns_root_zone_ooni_org
-}
-
 resource "aws_route53_record" "umami-ooni-org-_CNAME_" {
   name                             = "umami.ooni.org"
   records                          = ["xhgyj5se.up.railway.app"]


### PR DESCRIPTION
Unfortunately the digital ocean UI didn't have an export as csv or similar, so I basically ended up manually typing them up based on what was displayed in the UI:

![Screenshot 2024-04-11 at 14 11 49](https://github.com/ooni/devops/assets/424620/956ca665-73c6-424d-a977-17fa71180d61)
