### PR TITLE
feat: add alternative domains for oonith_service

### DIFF
--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -532,10 +532,10 @@ module "oonith_oohelperd" {
   ]
 
   // Note: Since we do not have a dns zone for ooni org, we test on io domains here
-  alternative_names = [
-    "5.th.ooni.io",
-    "6.th.ooni.io"
-  ]
+  alternative_names = {
+    "5.th.dev.ooni.io" = local.dns_zone_ooni_io,
+    "6.th.dev.ooni.io" = local.dns_zone_ooni_io,
+  }
 
   tags = merge(
     local.tags,

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -533,14 +533,8 @@ module "oonith_oohelperd" {
 
   // Note: Since we do not have a dns zone for ooni org, we test on io domains here
   alternative_names = [
-    {
-      name = "5.th.ooni.io",
-      type = "A"
-    },
-    {
-      name = "6.th.ooni.io",
-      type = "A"
-    }
+    "5.th.ooni.io",
+    "6.th.ooni.io"
   ]
 
   tags = merge(

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -531,6 +531,18 @@ module "oonith_oohelperd" {
     module.oonith_cluster.web_security_group_id
   ]
 
+  // Note: Since we do not have a dns zone for ooni org, we test on io domains here
+  alternative_names = [
+    {
+      name = "5.th.ooni.io",
+      type = "A"
+    },
+    {
+      name = "6.th.ooni.io",
+      type = "A"
+    }
+  ]
+
   tags = merge(
     local.tags,
     { Name = "ooni-tier0-oohelperd" }

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -535,6 +535,11 @@ module "oonith_oohelperd" {
     PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
   }
 
+  alternative_names = {
+    "5.th.ooni.org" = local.dns_root_zone_ooni_org,
+    "6.th.ooni.org" = local.dns_root_zone_ooni_org,
+  }
+
   oonith_service_security_groups = [
     module.oonith_cluster.web_security_group_id
   ]

--- a/tf/modules/oonith_service/main.tf
+++ b/tf/modules/oonith_service/main.tf
@@ -189,6 +189,8 @@ resource "aws_acm_certificate" "oonith_service" {
   domain_name       = "${var.service_name}.th.${var.stage}.ooni.io"
   validation_method = "DNS"
 
+  subject_alternative_names = var.alternative_names
+
   tags = var.tags
 
   lifecycle {
@@ -225,17 +227,12 @@ resource "aws_route53_record" "oonith_service_alias" {
   count = length(var.alternative_names)
 
   zone_id = var.dns_zone_ooni_io
-  name    = var.alternative_names[count.index].name
-  type    = var.alternative_names[count.index].type
+  name    = var.alternative_names[count.index]
+  type    = "A"
 
   alias {
     name                   = aws_alb.oonith_service.dns_name
     zone_id                = aws_alb.oonith_service.zone_id
     evaluate_target_health = true
   }
-}
-
-resource "aws_acm_certificate_validation" "oonith_service_alias" {
-  certificate_arn         = aws_acm_certificate.oonith_service.arn
-  validation_record_fqdns = [for record in aws_route53_record.oonith_service_alias : record.fqdn]
 }

--- a/tf/modules/oonith_service/main.tf
+++ b/tf/modules/oonith_service/main.tf
@@ -220,3 +220,22 @@ resource "aws_acm_certificate_validation" "oonith_service" {
     aws_route53_record.oonith_service
   ]
 }
+
+resource "aws_route53_record" "oonith_service_alias" {
+  count = length(var.alternative_names)
+
+  zone_id = var.dns_zone_ooni_io
+  name    = var.alternative_names[count.index].name
+  type    = var.alternative_names[count.index].type
+
+  alias {
+    name                   = aws_alb.oonith_service.dns_name
+    zone_id                = aws_alb.oonith_service.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "oonith_service_alias" {
+  certificate_arn         = aws_acm_certificate.oonith_service.arn
+  validation_record_fqdns = [for record in aws_route53_record.oonith_service_alias : record.fqdn]
+}

--- a/tf/modules/oonith_service/main.tf
+++ b/tf/modules/oonith_service/main.tf
@@ -203,6 +203,7 @@ resource "aws_route53_record" "oonith_service_validation" {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
+      domain_name = dvo.domain_name
     }
   }
 
@@ -211,7 +212,7 @@ resource "aws_route53_record" "oonith_service_validation" {
   records         = [each.value.record]
   ttl             = 60
   type            = each.value.type
-  zone_id         = lookup(var.alternative_names, each.value.name, var.dns_zone_ooni_io)
+  zone_id         = lookup(var.alternative_names,each.value.domain_name,var.dns_zone_ooni_io)
 }
 
 resource "aws_acm_certificate_validation" "oonith_service" {
@@ -219,7 +220,7 @@ resource "aws_acm_certificate_validation" "oonith_service" {
   validation_record_fqdns = [for record in aws_route53_record.oonith_service_validation : record.fqdn]
   depends_on = [
     aws_route53_record.oonith_service,
-    aws_route53_record.oonith_service_alias,
+    aws_route53_record.oonith_service_alias
   ]
 }
 

--- a/tf/modules/oonith_service/main.tf
+++ b/tf/modules/oonith_service/main.tf
@@ -55,7 +55,6 @@ resource "aws_ecs_task_definition" "oonith_service" {
         jsondecode(data.aws_ecs_task_definition.oonith_service_current.0.task_definition).ContainerDefinitions[0].image,
         var.default_docker_image_url
       ),
-      image  = var.default_docker_image_url,
       memory = var.task_memory,
       name   = local.name,
       portMappings = [

--- a/tf/modules/oonith_service/variables.tf
+++ b/tf/modules/oonith_service/variables.tf
@@ -48,6 +48,11 @@ variable "dns_zone_ooni_io" {
   description = "id of the DNS zone for ooni_io"
 }
 
+variable "dns_zone_ooni_org" {
+  description = "id of the DNS zone for ooni_org"
+  default     = ""
+}
+
 variable "default_docker_image_url" {
   description = "the url to the default docker image unless there is one already defined in the task definition"
 }
@@ -73,4 +78,13 @@ variable "oonith_service_security_groups" {
 
 variable "first_run" {
   default = false
+}
+
+variable "alternative_names" {
+  description = "list of alternative domain names to that should point to oohelperd"
+  type = list(object({
+    name = string
+    type = string
+  }))
+  default = []
 }

--- a/tf/modules/oonith_service/variables.tf
+++ b/tf/modules/oonith_service/variables.tf
@@ -81,7 +81,7 @@ variable "first_run" {
 }
 
 variable "alternative_names" {
-  description = "list of alternative domain names to that should point to oohelperd"
-  type = list(string)
-  default = []
+  description = "mapping of alternative domain names to zone_id. the domain name should be a fqdn that's in the zone_id being passed, otherwise it will be treated as a label"
+  type = map(string)
+  default = {}
 }

--- a/tf/modules/oonith_service/variables.tf
+++ b/tf/modules/oonith_service/variables.tf
@@ -82,9 +82,6 @@ variable "first_run" {
 
 variable "alternative_names" {
   description = "list of alternative domain names to that should point to oohelperd"
-  type = list(object({
-    name = string
-    type = string
-  }))
+  type = list(string)
   default = []
 }


### PR DESCRIPTION
This diff allows adding alternative domains which point to `oonith_service`. 