### PR TITLE
Add IPv6 support

### DIFF
--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -138,7 +138,7 @@ module "oonipg" {
   name                     = "ooni-tier0-postgres"
   aws_region               = var.aws_region
   vpc_id                   = module.network.vpc_id
-  subnet_ids               = module.network.vpc_subnet[*].id
+  subnet_ids               = module.network.vpc_subnet_public[*].id
   db_instance_class        = "db.t3.micro"
   db_storage_type          = "standard"
   db_allocated_storage     = "5"
@@ -251,7 +251,7 @@ module "ooni_backendproxy" {
   source = "../../modules/ooni_backendproxy"
 
   vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  subnet_ids = module.network.vpc_subnet_public[*].id
 
   key_name      = module.adm_iam_roles.oonidevops_key_name
   instance_type = "t2.micro"
@@ -270,7 +270,7 @@ module "ooniapi_cluster" {
   name       = "ooniapi-ecs-cluster"
   key_name   = module.adm_iam_roles.oonidevops_key_name
   vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  subnet_ids = module.network.vpc_subnet_public[*].id
 
   asg_min     = 2
   asg_max     = 6
@@ -290,11 +290,11 @@ module "oonith_cluster" {
   name       = "oonith-ecs-cluster"
   key_name   = module.adm_iam_roles.oonidevops_key_name
   vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  subnet_ids = module.network.vpc_subnet_public[*].id
 
-  asg_min     = 2
-  asg_max     = 6
-  asg_desired = 2
+  asg_min     = 1
+  asg_max     = 4
+  asg_desired = 1
 
   instance_type = "t2.small"
 
@@ -329,8 +329,9 @@ module "ooniapi_ooniprobe" {
   # First run should be set on first run to bootstrap the task definition
   # first_run = true
 
-  vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  vpc_id             = module.network.vpc_id
+  public_subnet_ids  = module.network.vpc_subnet_public[*].id
+  private_subnet_ids = module.network.vpc_subnet_private[*].id
 
   service_name             = "ooniprobe"
   default_docker_image_url = "ooni/api-ooniprobe:latest"
@@ -376,8 +377,9 @@ module "ooniapi_oonirun_deployer" {
 module "ooniapi_oonirun" {
   source = "../../modules/ooniapi_service"
 
-  vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  vpc_id             = module.network.vpc_id
+  public_subnet_ids  = module.network.vpc_subnet_public[*].id
+  private_subnet_ids = module.network.vpc_subnet_private[*].id
 
   service_name             = "oonirun"
   default_docker_image_url = "ooni/api-oonirun:latest"
@@ -422,8 +424,9 @@ module "ooniapi_ooniauth_deployer" {
 module "ooniapi_ooniauth" {
   source = "../../modules/ooniapi_service"
 
-  vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  vpc_id             = module.network.vpc_id
+  public_subnet_ids  = module.network.vpc_subnet_public[*].id
+  private_subnet_ids = module.network.vpc_subnet_private[*].id
 
   service_name             = "ooniauth"
   default_docker_image_url = "ooni/api-ooniauth:latest"
@@ -473,7 +476,7 @@ module "ooniapi_frontend" {
   source = "../../modules/ooniapi_frontend"
 
   vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  subnet_ids = module.network.vpc_subnet_public[*].id
 
   oonibackend_proxy_target_group_arn = module.ooni_backendproxy.alb_target_group_id
   ooniapi_oonirun_target_group_arn   = module.ooniapi_oonirun.alb_target_group_id
@@ -513,8 +516,9 @@ module "oonith_oohelperd_deployer" {
 module "oonith_oohelperd" {
   source = "../../modules/oonith_service"
 
-  vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  vpc_id             = module.network.vpc_id
+  public_subnet_ids  = module.network.vpc_subnet_public[*].id
+  private_subnet_ids = module.network.vpc_subnet_private[*].id
 
   service_name             = "oohelperd"
   default_docker_image_url = "ooni/oonith-oohelperd:latest"

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -536,6 +536,7 @@ module "oonith_oohelperd" {
   }
 
   alternative_names = {
+    "4.th.ooni.org" = local.dns_root_zone_ooni_org,
     "5.th.ooni.org" = local.dns_root_zone_ooni_org,
     "6.th.ooni.org" = local.dns_root_zone_ooni_org,
   }

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -277,9 +277,9 @@ module "ooniapi_cluster" {
   vpc_id     = module.network.vpc_id
   subnet_ids = module.network.vpc_subnet_public[*].id
 
-  asg_min     = 2
-  asg_max     = 6
-  asg_desired = 2
+  asg_min     = 3
+  asg_max     = 8
+  asg_desired = 3
 
   instance_type = "t2.small"
 
@@ -345,6 +345,8 @@ module "ooniapi_ooniprobe" {
   key_name                 = module.adm_iam_roles.oonidevops_key_name
   ecs_cluster_id           = module.ooniapi_cluster.cluster_id
 
+  service_desired_count = 2
+
   task_secrets = {
     POSTGRESQL_URL              = aws_secretsmanager_secret_version.oonipg_url.arn
     JWT_ENCRYPTION_KEY          = aws_secretsmanager_secret_version.jwt_secret.arn
@@ -394,6 +396,8 @@ module "ooniapi_oonirun" {
   key_name                 = module.adm_iam_roles.oonidevops_key_name
   ecs_cluster_id           = module.ooniapi_cluster.cluster_id
 
+  service_desired_count = 2
+
   task_secrets = {
     POSTGRESQL_URL              = aws_secretsmanager_secret_version.oonipg_url.arn
     JWT_ENCRYPTION_KEY          = aws_secretsmanager_secret_version.jwt_secret.arn
@@ -441,6 +445,8 @@ module "ooniapi_ooniauth" {
   dns_zone_ooni_io         = local.dns_zone_ooni_io
   key_name                 = module.adm_iam_roles.oonidevops_key_name
   ecs_cluster_id           = module.ooniapi_cluster.cluster_id
+
+  service_desired_count = 2
 
   task_secrets = {
     POSTGRESQL_URL              = aws_secretsmanager_secret_version.oonipg_url.arn
@@ -534,6 +540,8 @@ module "oonith_oohelperd" {
   dns_zone_ooni_io         = local.dns_zone_ooni_io
   key_name                 = module.adm_iam_roles.oonidevops_key_name
   ecs_cluster_id           = module.oonith_cluster.cluster_id
+
+  service_desired_count = 2
 
   task_secrets = {
     PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -143,7 +143,7 @@ module "oonipg" {
   name                     = "ooni-tier0-postgres"
   aws_region               = var.aws_region
   vpc_id                   = module.network.vpc_id
-  subnet_ids               = module.network.vpc_subnet[*].id
+  subnet_ids               = module.network.vpc_subnet_public[*].id
   db_instance_class        = "db.t3.micro"
   db_storage_type          = "standard"
   db_allocated_storage     = "5"
@@ -256,7 +256,7 @@ module "ooni_backendproxy" {
   source = "../../modules/ooni_backendproxy"
 
   vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  subnet_ids = module.network.vpc_subnet_public[*].id
 
   key_name      = module.adm_iam_roles.oonidevops_key_name
   instance_type = "t2.micro"
@@ -275,7 +275,7 @@ module "ooniapi_cluster" {
   name       = "ooniapi-ecs-cluster"
   key_name   = module.adm_iam_roles.oonidevops_key_name
   vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  subnet_ids = module.network.vpc_subnet_public[*].id
 
   asg_min     = 2
   asg_max     = 6
@@ -295,7 +295,7 @@ module "oonith_cluster" {
   name       = "oonith-ecs-cluster"
   key_name   = module.adm_iam_roles.oonidevops_key_name
   vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  subnet_ids = module.network.vpc_subnet_public[*].id
 
   asg_min     = 2
   asg_max     = 6
@@ -334,8 +334,9 @@ module "ooniapi_ooniprobe" {
   # First run should be set on first run to bootstrap the task definition
   #first_run = true
 
-  vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  vpc_id             = module.network.vpc_id
+  private_subnet_ids = module.network.vpc_subnet_private[*].id
+  public_subnet_ids  = module.network.vpc_subnet_public[*].id
 
   service_name             = "ooniprobe"
   default_docker_image_url = "ooni/api-ooniprobe:latest"
@@ -382,8 +383,9 @@ module "ooniapi_oonirun" {
   source = "../../modules/ooniapi_service"
   #first_run = true
 
-  vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  vpc_id             = module.network.vpc_id
+  private_subnet_ids = module.network.vpc_subnet_private[*].id
+  public_subnet_ids  = module.network.vpc_subnet_public[*].id
 
   service_name             = "oonirun"
   default_docker_image_url = "ooni/api-oonirun:latest"
@@ -429,8 +431,9 @@ module "ooniapi_ooniauth" {
   source = "../../modules/ooniapi_service"
   #first_run = true
 
-  vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  vpc_id             = module.network.vpc_id
+  private_subnet_ids = module.network.vpc_subnet_private[*].id
+  public_subnet_ids  = module.network.vpc_subnet_public[*].id
 
   service_name             = "ooniauth"
   default_docker_image_url = "ooni/api-ooniauth:latest"
@@ -480,7 +483,7 @@ module "ooniapi_frontend" {
   source = "../../modules/ooniapi_frontend"
 
   vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  subnet_ids = module.network.vpc_subnet_public[*].id
 
   oonibackend_proxy_target_group_arn = module.ooni_backendproxy.alb_target_group_id
   ooniapi_oonirun_target_group_arn   = module.ooniapi_oonirun.alb_target_group_id
@@ -521,8 +524,9 @@ module "oonith_oohelperd" {
   source = "../../modules/oonith_service"
   #first_run = true
 
-  vpc_id     = module.network.vpc_id
-  subnet_ids = module.network.vpc_subnet[*].id
+  vpc_id             = module.network.vpc_id
+  private_subnet_ids = module.network.vpc_subnet_private[*].id
+  public_subnet_ids  = module.network.vpc_subnet_public[*].id
 
   service_name             = "oohelperd"
   default_docker_image_url = "ooni/oonith-oohelperd:latest"

--- a/tf/modules/ecs_cluster/main.tf
+++ b/tf/modules/ecs_cluster/main.tf
@@ -72,6 +72,7 @@ resource "aws_security_group" "web" {
     cidr_blocks = [
       "0.0.0.0/0",
     ]
+    ipv6_cidr_blocks = ["0::0/0"]
   }
 
   tags = var.tags

--- a/tf/modules/ecs_cluster/main.tf
+++ b/tf/modules/ecs_cluster/main.tf
@@ -147,6 +147,7 @@ resource "aws_launch_template" "container_host" {
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
+    ipv6_address_count          = 1
     security_groups = [
       aws_security_group.container_host.id,
     ]

--- a/tf/modules/ecs_cluster/main.tf
+++ b/tf/modules/ecs_cluster/main.tf
@@ -72,7 +72,7 @@ resource "aws_security_group" "web" {
     cidr_blocks = [
       "0.0.0.0/0",
     ]
-    ipv6_cidr_blocks = ["0::0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = var.tags
@@ -121,7 +121,7 @@ resource "aws_security_group" "container_host" {
     to_port          = 0
     protocol         = "-1"
     cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["0::0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = var.tags

--- a/tf/modules/ecs_cluster/main.tf
+++ b/tf/modules/ecs_cluster/main.tf
@@ -116,10 +116,11 @@ resource "aws_security_group" "container_host" {
   }
 
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["0::0/0"]
   }
 
   tags = var.tags

--- a/tf/modules/ecs_cluster/variables.tf
+++ b/tf/modules/ecs_cluster/variables.tf
@@ -17,6 +17,7 @@ variable "vpc_id" {
 
 variable "subnet_ids" {
   description = "the ids of the subnet of the subnets to deploy the instance into"
+  type        = list(string)
 }
 
 variable "tags" {

--- a/tf/modules/ecs_cluster/variables.tf
+++ b/tf/modules/ecs_cluster/variables.tf
@@ -31,13 +31,18 @@ variable "name" {
 }
 
 variable "asg_min" {
-  description = "Min numbers of servers in ASG"
+  description = <<EOT
+                Min numbers of servers in ASG. Keep in mind the ENI restrictions,
+                where small-large have a limit of 3 and micro has a limit of 2.
+                This means that if you plan to run 3 tasks in the ECS cluster with a task count of 2,
+                you need a minimum of 3  in the ASG
+                EOT
   default     = 1
 }
 
 variable "asg_max" {
   description = "Max numbers of servers in ASG"
-  default     = 4
+  default     = 6
 }
 
 variable "asg_desired" {

--- a/tf/modules/network/main.tf
+++ b/tf/modules/network/main.tf
@@ -23,14 +23,26 @@ resource "aws_internet_gateway" "gw" {
   vpc_id = aws_vpc.main.id
 }
 
+resource "aws_egress_only_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = var.tags
+}
+
+
 resource "aws_route_table" "r" {
   vpc_id = aws_vpc.main.id
 
   route {
-    cidr_block      = "0.0.0.0/0"
-    ipv6_cidr_block = "::/0"
-    gateway_id      = aws_internet_gateway.gw.id
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw.id
   }
+
+  route {
+    ipv6_cidr_block        = "::/0"
+    egress_only_gateway_id = aws_egress_only_internet_gateway.gw.id
+  }
+
 
   tags = var.tags
 }

--- a/tf/modules/network/main.tf
+++ b/tf/modules/network/main.tf
@@ -9,28 +9,79 @@ resource "aws_vpc" "main" {
   tags = var.tags
 }
 
-resource "aws_subnet" "main" {
-  count             = var.az_count
-  cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)
-  ipv6_cidr_block   = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, count.index)
-  availability_zone = var.aws_availability_zones_available.names[count.index]
+resource "aws_subnet" "public" {
+  count = var.az_count
+
+  cidr_block = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)
+
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, count.index)
+  assign_ipv6_address_on_creation = true
+
+  availability_zone       = element(var.aws_availability_zones_available.names, count.index)
+  vpc_id                  = aws_vpc.main.id
+  map_public_ip_on_launch = true
+
+  depends_on = [aws_internet_gateway.gw]
+
+  tags = {
+    Name = "ooni-public-subnet-${count.index}"
+  }
+}
+
+moved {
+  from = aws_subnet.main
+  to   = aws_subnet.public
+}
+
+resource "aws_subnet" "private" {
+  count = var.az_count
+
+  cidr_block = cidrsubnet(aws_vpc.main.cidr_block, 8, var.az_count + count.index)
+
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, var.az_count + count.index)
+  assign_ipv6_address_on_creation = true
+
+  availability_zone = element(var.aws_availability_zones_available.names, var.az_count + count.index)
   vpc_id            = aws_vpc.main.id
 
-  tags = var.tags
+  depends_on = [aws_internet_gateway.gw]
+
+  tags = {
+    Name = "ooni-private-subnet-${count.index}"
+  }
+}
+
+resource "aws_eip" "main" {
+  count      = var.az_count
+  domain     = "vpc"
+  depends_on = [aws_internet_gateway.gw]
+}
+
+resource "aws_nat_gateway" "nat_gw" {
+  count         = var.az_count
+  subnet_id     = element(aws_subnet.private[*].id, count.index)
+  allocation_id = element(aws_eip.main[*].id, count.index)
+
+  depends_on = [aws_internet_gateway.gw]
 }
 
 resource "aws_internet_gateway" "gw" {
   vpc_id = aws_vpc.main.id
+
 }
 
-resource "aws_egress_only_internet_gateway" "gw" {
+resource "aws_egress_only_internet_gateway" "egress_gw" {
   vpc_id = aws_vpc.main.id
 
   tags = var.tags
 }
 
+moved {
+  from = aws_egress_only_internet_gateway.gw
+  to   = aws_egress_only_internet_gateway.egress_gw
+}
 
-resource "aws_route_table" "r" {
+resource "aws_route_table" "public" {
   vpc_id = aws_vpc.main.id
 
   route {
@@ -40,15 +91,41 @@ resource "aws_route_table" "r" {
 
   route {
     ipv6_cidr_block        = "::/0"
-    egress_only_gateway_id = aws_egress_only_internet_gateway.gw.id
+    egress_only_gateway_id = aws_egress_only_internet_gateway.egress_gw.id
   }
 
-
-  tags = var.tags
+  tags = {
+    Name = "ooni-public-route-table"
+  }
 }
 
-resource "aws_route_table_association" "a" {
+resource "aws_route_table_association" "public" {
   count          = var.az_count
-  subnet_id      = element(aws_subnet.main[*].id, count.index)
-  route_table_id = aws_route_table.r.id
+  subnet_id      = element(aws_subnet.public[*].id, count.index)
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  count  = var.az_count
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = element(aws_nat_gateway.nat_gw[*].id, count.index)
+  }
+
+  route {
+    ipv6_cidr_block        = "::/0"
+    egress_only_gateway_id = aws_egress_only_internet_gateway.egress_gw.id
+  }
+
+  tags = {
+    Name = "ooni-public-route-table-${count.index}"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = var.az_count
+  subnet_id      = element(aws_subnet.private[*].id, count.index)
+  route_table_id = element(aws_route_table.private[*].id, count.index)
 }

--- a/tf/modules/network/main.tf
+++ b/tf/modules/network/main.tf
@@ -4,12 +4,15 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
   enable_dns_support   = true
 
+  assign_generated_ipv6_cidr_block = true
+
   tags = var.tags
 }
 
 resource "aws_subnet" "main" {
   count             = var.az_count
   cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, count.index)
   availability_zone = var.aws_availability_zones_available.names[count.index]
   vpc_id            = aws_vpc.main.id
 
@@ -24,8 +27,9 @@ resource "aws_route_table" "r" {
   vpc_id = aws_vpc.main.id
 
   route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.gw.id
+    cidr_block      = "0.0.0.0/0"
+    ipv6_cidr_block = "::/0"
+    gateway_id      = aws_internet_gateway.gw.id
   }
 
   tags = var.tags

--- a/tf/modules/network/main.tf
+++ b/tf/modules/network/main.tf
@@ -28,11 +28,6 @@ resource "aws_subnet" "public" {
   }
 }
 
-moved {
-  from = aws_subnet.main
-  to   = aws_subnet.public
-}
-
 resource "aws_subnet" "private" {
   count = var.az_count
 
@@ -84,11 +79,6 @@ resource "aws_egress_only_internet_gateway" "egress_gw" {
   tags = {
     Name = "ooni-egressonly-gw"
   }
-}
-
-moved {
-  from = aws_egress_only_internet_gateway.gw
-  to   = aws_egress_only_internet_gateway.egress_gw
 }
 
 resource "aws_route_table" "public" {

--- a/tf/modules/network/main.tf
+++ b/tf/modules/network/main.tf
@@ -41,8 +41,9 @@ resource "aws_subnet" "private" {
   ipv6_cidr_block                 = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, var.az_count + count.index)
   assign_ipv6_address_on_creation = true
 
-  availability_zone = element(var.aws_availability_zones_available.names, var.az_count + count.index)
-  vpc_id            = aws_vpc.main.id
+  availability_zone       = element(var.aws_availability_zones_available.names, var.az_count + count.index)
+  vpc_id                  = aws_vpc.main.id
+  map_public_ip_on_launch = false
 
   depends_on = [aws_internet_gateway.gw]
 
@@ -67,7 +68,6 @@ resource "aws_nat_gateway" "nat_gw" {
 
 resource "aws_internet_gateway" "gw" {
   vpc_id = aws_vpc.main.id
-
 }
 
 resource "aws_egress_only_internet_gateway" "egress_gw" {

--- a/tf/modules/network/outputs.tf
+++ b/tf/modules/network/outputs.tf
@@ -3,7 +3,12 @@ output "vpc_id" {
   value       = aws_vpc.main.id
 }
 
-output "vpc_subnet" {
+output "vpc_subnet_public" {
   description = "The value of the subnet associated to the VPC"
-  value       = aws_subnet.main
+  value       = aws_subnet.public
+}
+
+output "vpc_subnet_private" {
+  description = "The value of the subnet associated to the VPC"
+  value       = aws_subnet.private
 }

--- a/tf/modules/network/variables.tf
+++ b/tf/modules/network/variables.tf
@@ -9,7 +9,7 @@ variable "aws_availability_zones_available" {
 }
 
 variable "vpc_main_cidr_block" {
-  description = "the CIDR block of the default VPC"
+  description = "the start address of the main VPC cidr"
   default     = "10.0.0.0/16"
 }
 

--- a/tf/modules/ooniapi_service/main.tf
+++ b/tf/modules/ooniapi_service/main.tf
@@ -57,6 +57,9 @@ resource "aws_ecs_task_definition" "ooniapi_service" {
       ),
       memory = var.task_memory,
       name   = local.name,
+
+      network_mode = "awsvpc",
+
       portMappings = [
         {
           containerPort = local.container_port,

--- a/tf/modules/ooniapi_service/main.tf
+++ b/tf/modules/ooniapi_service/main.tf
@@ -103,20 +103,33 @@ resource "aws_security_group" "ooniapi_service_ecs" {
   vpc_id      = var.vpc_id
 
   ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
     from_port        = 80
     to_port          = 80
     protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
     from_port        = 0
     to_port          = 0
     protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
+
 }
 
 resource "aws_ecs_service" "ooniapi_service" {
@@ -141,7 +154,7 @@ resource "aws_ecs_service" "ooniapi_service" {
   }
 
   network_configuration {
-    subnets         = var.subnet_ids
+    subnets         = var.private_subnet_ids
     security_groups = [aws_security_group.ooniapi_service_ecs.id]
   }
 
@@ -186,7 +199,7 @@ resource "aws_alb_target_group" "ooniapi_service_mapped" {
 
 resource "aws_alb" "ooniapi_service" {
   name            = local.name
-  subnets         = var.subnet_ids
+  subnets         = var.public_subnet_ids
   security_groups = var.ooniapi_service_security_groups
 
   tags = var.tags

--- a/tf/modules/ooniapi_service/main.tf
+++ b/tf/modules/ooniapi_service/main.tf
@@ -103,16 +103,16 @@ resource "aws_security_group" "ooniapi_service_ecs" {
   vpc_id      = var.vpc_id
 
   ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
-    from_port        = 80
-    to_port          = 80
-    protocol         = "tcp"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
     ipv6_cidr_blocks = ["::/0"]
   }
 
@@ -139,7 +139,7 @@ resource "aws_ecs_service" "ooniapi_service" {
   desired_count   = var.service_desired_count
 
   deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent         = 100
+  deployment_maximum_percent         = 200
 
   load_balancer {
     target_group_arn = aws_alb_target_group.ooniapi_service_direct.id

--- a/tf/modules/ooniapi_service/main.tf
+++ b/tf/modules/ooniapi_service/main.tf
@@ -105,7 +105,7 @@ resource "aws_security_group" "ooniapi_service_ecs" {
   ingress {
     from_port        = 80
     to_port          = 80
-    protocol         = "-1"
+    protocol         = "tcp"
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
@@ -142,7 +142,7 @@ resource "aws_ecs_service" "ooniapi_service" {
 
   network_configuration {
     subnets         = var.subnet_ids
-    security_groups = aws_security_group.ooniapi_service_ecs.id
+    security_groups = [aws_security_group.ooniapi_service_ecs.id]
   }
 
   depends_on = [

--- a/tf/modules/ooniapi_service/main.tf
+++ b/tf/modules/ooniapi_service/main.tf
@@ -46,7 +46,9 @@ data "aws_ecs_task_definition" "ooniapi_service_current" {
 }
 
 resource "aws_ecs_task_definition" "ooniapi_service" {
-  family = "${local.name}-td"
+  family       = "${local.name}-td"
+  network_mode = "awsvpc"
+
   container_definitions = jsonencode([
     {
       cpu       = var.task_cpu,
@@ -58,12 +60,9 @@ resource "aws_ecs_task_definition" "ooniapi_service" {
       memory = var.task_memory,
       name   = local.name,
 
-      network_mode = "awsvpc",
-
       portMappings = [
         {
           containerPort = local.container_port,
-          hostPort      = 0
         }
       ],
       environment = [

--- a/tf/modules/ooniapi_service/main.tf
+++ b/tf/modules/ooniapi_service/main.tf
@@ -97,6 +97,28 @@ resource "aws_ecs_task_definition" "ooniapi_service" {
   track_latest       = true
 }
 
+resource "aws_security_group" "ooniapi_service_ecs" {
+  name        = "${local.name}_ecs-sg"
+  description = "Allow all traffic"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port        = 80
+    to_port          = 80
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
 resource "aws_ecs_service" "ooniapi_service" {
   name            = local.name
   cluster         = var.ecs_cluster_id
@@ -119,7 +141,8 @@ resource "aws_ecs_service" "ooniapi_service" {
   }
 
   network_configuration {
-    subnets = var.subnet_ids
+    subnets         = var.subnet_ids
+    security_groups = aws_security_group.ooniapi_service_ecs.id
   }
 
   depends_on = [

--- a/tf/modules/ooniapi_service/variables.tf
+++ b/tf/modules/ooniapi_service/variables.tf
@@ -50,7 +50,7 @@ variable "task_cpu" {
 }
 
 variable "task_memory" {
-  default     = 1024
+  default     = 512
   description = "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size"
 }
 

--- a/tf/modules/ooniapi_service/variables.tf
+++ b/tf/modules/ooniapi_service/variables.tf
@@ -23,7 +23,12 @@ variable "vpc_id" {
   description = "the id of the VPC to deploy the instance into"
 }
 
-variable "subnet_ids" {
+variable "public_subnet_ids" {
+  description = "the ids of the subnet of the subnets to deploy the instance into"
+  type        = list(string)
+}
+
+variable "private_subnet_ids" {
   description = "the ids of the subnet of the subnets to deploy the instance into"
   type        = list(string)
 }
@@ -36,16 +41,16 @@ variable "tags" {
 
 variable "service_desired_count" {
   description = "Desired numbers of instances in the ecs service"
-  default     = 2
+  default     = 1
 }
 
 variable "task_cpu" {
-  default     = 256
+  default     = 512
   description = "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size"
 }
 
 variable "task_memory" {
-  default     = 512
+  default     = 1024
   description = "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size"
 }
 

--- a/tf/modules/ooniapi_service/variables.tf
+++ b/tf/modules/ooniapi_service/variables.tf
@@ -25,6 +25,7 @@ variable "vpc_id" {
 
 variable "subnet_ids" {
   description = "the ids of the subnet of the subnets to deploy the instance into"
+  type        = list(string)
 }
 
 variable "tags" {

--- a/tf/modules/oonith_service/main.tf
+++ b/tf/modules/oonith_service/main.tf
@@ -57,6 +57,9 @@ resource "aws_ecs_task_definition" "oonith_service" {
       ),
       memory = var.task_memory,
       name   = local.name,
+
+      network_mode = "awsvpc",
+
       portMappings = [
         {
           containerPort = local.container_port,
@@ -200,9 +203,9 @@ resource "aws_acm_certificate" "oonith_service" {
 resource "aws_route53_record" "oonith_service_validation" {
   for_each = {
     for dvo in aws_acm_certificate.oonith_service.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
+      name        = dvo.resource_record_name
+      record      = dvo.resource_record_value
+      type        = dvo.resource_record_type
       domain_name = dvo.domain_name
     }
   }
@@ -212,7 +215,7 @@ resource "aws_route53_record" "oonith_service_validation" {
   records         = [each.value.record]
   ttl             = 60
   type            = each.value.type
-  zone_id         = lookup(var.alternative_names,each.value.domain_name,var.dns_zone_ooni_io)
+  zone_id         = lookup(var.alternative_names, each.value.domain_name, var.dns_zone_ooni_io)
 }
 
 resource "aws_acm_certificate_validation" "oonith_service" {

--- a/tf/modules/oonith_service/main.tf
+++ b/tf/modules/oonith_service/main.tf
@@ -1,5 +1,10 @@
 locals {
   name = "oonith-service-${var.service_name}"
+  # We construct a stripped name that is without the "ooni" substring and all
+  # vocals are stripped.
+  stripped_name = replace(replace(var.service_name, "ooni", ""), "[aeiou]", "")
+  # Short prefix should be less than 5 characters
+  short_prefix = "oo${substr(var.service_name, 0, 3)}"
 }
 
 resource "aws_iam_role" "oonith_service_task" {
@@ -108,6 +113,10 @@ resource "aws_ecs_service" "oonith_service" {
     container_port   = "80"
   }
 
+  network_configuration {
+    subnets = var.subnet_ids
+  }
+
   depends_on = [
     aws_alb_listener.oonith_service_http,
   ]
@@ -119,11 +128,15 @@ resource "aws_ecs_service" "oonith_service" {
 
 # The direct
 resource "aws_alb_target_group" "oonith_service_direct" {
-  name        = "${local.name}-direct"
+  name_prefix = "${local.short_prefix}D"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = var.vpc_id
   target_type = "ip"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 
   tags = var.tags
 }

--- a/tf/modules/oonith_service/main.tf
+++ b/tf/modules/oonith_service/main.tf
@@ -127,7 +127,7 @@ resource "aws_ecs_service" "oonith_service" {
   desired_count   = var.service_desired_count
 
   deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent         = 100
+  deployment_maximum_percent         = 200
 
   load_balancer {
     target_group_arn = aws_alb_target_group.oonith_service_direct.id

--- a/tf/modules/oonith_service/main.tf
+++ b/tf/modules/oonith_service/main.tf
@@ -47,6 +47,9 @@ data "aws_ecs_task_definition" "oonith_service_current" {
 
 resource "aws_ecs_task_definition" "oonith_service" {
   family = "${local.name}-td"
+
+  network_mode = "awsvpc"
+
   container_definitions = jsonencode([
     {
       cpu       = var.task_cpu,
@@ -58,12 +61,10 @@ resource "aws_ecs_task_definition" "oonith_service" {
       memory = var.task_memory,
       name   = local.name,
 
-      network_mode = "awsvpc",
 
       portMappings = [
         {
           containerPort = local.container_port,
-          hostPort      = 0
         }
       ],
       environment = [
@@ -118,10 +119,11 @@ resource "aws_ecs_service" "oonith_service" {
 
 # The direct
 resource "aws_alb_target_group" "oonith_service_direct" {
-  name     = "${local.name}-direct"
-  port     = 80
-  protocol = "HTTP"
-  vpc_id   = var.vpc_id
+  name        = "${local.name}-direct"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
 
   tags = var.tags
 }

--- a/tf/modules/oonith_service/main.tf
+++ b/tf/modules/oonith_service/main.tf
@@ -66,10 +66,10 @@ resource "aws_ecs_task_definition" "oonith_service" {
       memory = var.task_memory,
       name   = local.name,
 
-
       portMappings = [
         {
           containerPort = local.container_port,
+          hostPort      = local.container_port,
         }
       ],
       environment = [

--- a/tf/modules/oonith_service/main.tf
+++ b/tf/modules/oonith_service/main.tf
@@ -106,7 +106,7 @@ resource "aws_security_group" "oonith_service_ecs" {
   ingress {
     from_port        = 80
     to_port          = 80
-    protocol         = "-1"
+    protocol         = "tcp"
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
@@ -137,7 +137,7 @@ resource "aws_ecs_service" "oonith_service" {
 
   network_configuration {
     subnets         = var.subnet_ids
-    security_groups = aws_security_group.oonith_service_ecs.id
+    security_groups = [aws_security_group.oonith_service_ecs.id]
   }
 
   depends_on = [

--- a/tf/modules/oonith_service/main.tf
+++ b/tf/modules/oonith_service/main.tf
@@ -98,6 +98,28 @@ resource "aws_ecs_task_definition" "oonith_service" {
   track_latest       = true
 }
 
+resource "aws_security_group" "oonith_service_ecs" {
+  name        = "${local.name}_ecs-sg"
+  description = "Allow all traffic"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port        = 80
+    to_port          = 80
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
 resource "aws_ecs_service" "oonith_service" {
   name            = local.name
   cluster         = var.ecs_cluster_id
@@ -114,7 +136,8 @@ resource "aws_ecs_service" "oonith_service" {
   }
 
   network_configuration {
-    subnets = var.subnet_ids
+    subnets         = var.subnet_ids
+    security_groups = aws_security_group.oonith_service_ecs.id
   }
 
   depends_on = [

--- a/tf/modules/oonith_service/main.tf
+++ b/tf/modules/oonith_service/main.tf
@@ -104,9 +104,9 @@ resource "aws_security_group" "oonith_service_ecs" {
   vpc_id      = var.vpc_id
 
   ingress {
-    from_port        = 80
-    to_port          = 80
-    protocol         = "tcp"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
@@ -136,7 +136,7 @@ resource "aws_ecs_service" "oonith_service" {
   }
 
   network_configuration {
-    subnets         = var.subnet_ids
+    subnets         = var.private_subnet_ids
     security_groups = [aws_security_group.oonith_service_ecs.id]
   }
 
@@ -179,7 +179,7 @@ resource "aws_alb_target_group" "oonith_service_direct" {
 
 resource "aws_alb" "oonith_service" {
   name            = local.name
-  subnets         = var.subnet_ids
+  subnets         = var.public_subnet_ids
   security_groups = var.oonith_service_security_groups
 
   tags = var.tags

--- a/tf/modules/oonith_service/variables.tf
+++ b/tf/modules/oonith_service/variables.tf
@@ -46,7 +46,7 @@ variable "task_cpu" {
 }
 
 variable "task_memory" {
-  default     = 1024
+  default     = 512
   description = "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size"
 }
 

--- a/tf/modules/oonith_service/variables.tf
+++ b/tf/modules/oonith_service/variables.tf
@@ -19,8 +19,14 @@ variable "vpc_id" {
   description = "the id of the VPC to deploy the instance into"
 }
 
-variable "subnet_ids" {
-  description = "the ids of the subnet of the subnets to deploy the instance into"
+variable "public_subnet_ids" {
+  description = "the ids of the public subnet of the subnets to deploy the instance into"
+  type        = list(string)
+}
+
+variable "private_subnet_ids" {
+  description = "the ids of the private subnet of the subnets to deploy the instance into"
+  type        = list(string)
 }
 
 variable "tags" {
@@ -31,16 +37,16 @@ variable "tags" {
 
 variable "service_desired_count" {
   description = "Desired numbers of instances in the ecs service"
-  default     = 2
+  default     = 1
 }
 
 variable "task_cpu" {
-  default     = 256
+  default     = 512
   description = "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size"
 }
 
 variable "task_memory" {
-  default     = 512
+  default     = 1024
   description = "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size"
 }
 
@@ -82,6 +88,6 @@ variable "first_run" {
 
 variable "alternative_names" {
   description = "mapping of alternative domain names to zone_id. the domain name should be a fqdn that's in the zone_id being passed, otherwise it will be treated as a label"
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
In order to support IPv6 on AWS we had to do a major rework of the networking configuration of the VPC and ECS clusters.

In case you like to enjoy some some trivia about why IPv6 support is so weak in AWS, check these links:
* https://news.ycombinator.com/item?id=37608900
* https://github.com/DuckbillGroup/aws-ipv6-gaps
* https://github.com/aws/containers-roadmap/issues/1340

More details follow:
* ECS tasks network mode has been switched to awsvpc, which is the [official way to support IPv6](https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-ecs-supports-ipv6-in-awsvpc-networking-mode/).
* Separate the networking stack into private and public. The routing table of the public network has direct IPv4 and IPv6 routes configured, while the private network uses NAT to route to the internet.
* For NAT to work we also need to allocate elastic IPs, one for each availability zone we would like to support.

In order to get the networking to work properly in ECS, we setup the container host to make use of the public network to have direct access to the internet, while the ECS container itself uses the private NATed network. This is the desired configuration because we don't want to directly expose the container to the internet, but rather map the container port to the public internet accessible endpoint via load balancer.