### PR TITLE
Move 3.th.ooni.org over to AWS

### DIFF
--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -88,8 +88,6 @@ scrape_configs:
         - 0.th.ooni.org:19999
         - 1.th.ooni.org:19999
         - 2.th.ooni.org:19999
-        - 3.th.ooni.org:19999
-        # - 2.th.ooni.org:19999
 
   - job_name: 'test-helpers'
     scrape_interval: 5s
@@ -100,7 +98,6 @@ scrape_configs:
         - 0.th.ooni.org:9001
         - 1.th.ooni.org:9001
         - 2.th.ooni.org:9001
-        - 3.th.ooni.org:9001
 
   - job_name: 'ooni-api'
     scrape_interval: 5s

--- a/ansible/roles/prometheus/vars/main.yml
+++ b/ansible/roles/prometheus/vars/main.yml
@@ -27,6 +27,7 @@ blackbox_jobs:
       - "https://1.th.ooni.org/"
       - "https://2.th.ooni.org/"
       - "https://3.th.ooni.org/"
+      - "https://4.th.ooni.org/"
 
   - name: "ooni collector"
     module: "ooni_collector_ok"

--- a/tf/environments/prod/dns_records.tf
+++ b/tf/environments/prod/dns_records.tf
@@ -1000,23 +1000,6 @@ resource "aws_route53_record" "test-ooni-nu-_NS_" {
 
 ## Records for the th.ooni.org zone
 
-
-resource "aws_route53_record" "_3-th-ooni-org-_AAAA_" {
-  name    = "3.th.ooni.org"
-  records = ["2604:a880:4:1d0::69e:f000"]
-  ttl     = "60"
-  type    = "AAAA"
-  zone_id = local.dns_root_zone_ooni_org
-}
-
-resource "aws_route53_record" "_3-th-ooni-org-_A_" {
-  name    = "3.th.ooni.org"
-  records = ["146.190.119.3"]
-  ttl     = "60"
-  type    = "A"
-  zone_id = local.dns_root_zone_ooni_org
-}
-
 resource "aws_route53_record" "_2-th-ooni-org-_A_" {
   name    = "2.th.ooni.org"
   records = ["161.35.89.250"]

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -563,9 +563,8 @@ module "oonith_oohelperd" {
   }
 
   alternative_names = {
-    "4.th.ooni.org" = local.dns_root_zone_ooni_org,
-    "5.th.ooni.org" = local.dns_root_zone_ooni_org,
-    "6.th.ooni.org" = local.dns_root_zone_ooni_org,
+    "3.th.ooni.org" = local.dns_root_zone_ooni_org,
+    "4.th.ooni.org" = local.dns_root_zone_ooni_org
   }
 
   oonith_service_security_groups = [


### PR DESCRIPTION
* Drop 3.th.ooni.org from the root DNS zone
* Add 3.th.ooni.org from the alternative domains
* Remove 5,6.th.ooni.org from the alternative domains (there were only used for internal testing and never shared)