### PR TITLE
feat: destroy quic.ooni.org domain

### DIFF
--- a/tf/environments/prod/dns_records.tf
+++ b/tf/environments/prod/dns_records.tf
@@ -302,14 +302,6 @@ resource "aws_route53_record" "prometheus-ooni-org-_CNAME_" {
   zone_id = local.dns_root_zone_ooni_org
 }
 
-resource "aws_route53_record" "quic-ooni-org-_A_" {
-  name    = "quic.ooni.org"
-  records = ["167.99.36.132"]
-  ttl     = "1799"
-  type    = "A"
-  zone_id = local.dns_root_zone_ooni_org
-}
-
 resource "aws_route53_record" "run-ooni-org-_CNAME_" {
   name    = "run.ooni.org"
   records = ["cname.vercel-dns.com"]


### PR DESCRIPTION
We no longer have use for the quic.ooni.org domain. It makes sense to kill it to avoid any unexpected attack planes.