### PR TITLE
feat: ipv6 support in ooni-backendproxy

### DIFF
--- a/tf/modules/ooni_backendproxy/main.tf
+++ b/tf/modules/ooni_backendproxy/main.tf
@@ -23,7 +23,7 @@ resource "aws_security_group" "nginx_sg" {
     to_port     = 22
     cidr_blocks = ["0.0.0.0/0"]
   }
-
+  
   egress {
     from_port = 0
     to_port   = 0
@@ -32,6 +32,13 @@ resource "aws_security_group" "nginx_sg" {
     cidr_blocks = [
       "0.0.0.0/0",
     ]
+  }
+  
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   lifecycle {

--- a/tf/modules/ooni_backendproxy/main.tf
+++ b/tf/modules/ooni_backendproxy/main.tf
@@ -23,7 +23,7 @@ resource "aws_security_group" "nginx_sg" {
     to_port     = 22
     cidr_blocks = ["0.0.0.0/0"]
   }
- 
+
   egress {
     from_port = 0
     to_port   = 0

--- a/tf/modules/ooni_backendproxy/main.tf
+++ b/tf/modules/ooni_backendproxy/main.tf
@@ -23,7 +23,7 @@ resource "aws_security_group" "nginx_sg" {
     to_port     = 22
     cidr_blocks = ["0.0.0.0/0"]
   }
-  
+ 
   egress {
     from_port = 0
     to_port   = 0

--- a/tf/modules/ooni_backendproxy/templates/setup-backend-proxy.sh
+++ b/tf/modules/ooni_backendproxy/templates/setup-backend-proxy.sh
@@ -16,6 +16,8 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Host \$host;
     }
+
+    error_log /var/log/nginx/error.log;
 }
 EOF
 sudo mv $tmpfile /etc/nginx/sites-available/default


### PR DESCRIPTION
The `api.dev.ooni.org` domain was reportedly failing with the check-in API as reported here: https://github.com/ooni/probe/issues/2741. On more inspection, we found that the `nginx` server was not configured with IPv6 support which caused the connection between the upstream server and the EC2 instance to time out. The `/var/log/nginx/error.log` logs found on the machine:
```
2024/06/05 09:07:33 [error] 89061#89061: *519419 upstream timed out (110: Unknown error) while connecting to upstream, client: 10.0.1.164, server: _, request: "POST /api/v1/check-in HTTP/1.1", upstream: "https://[2a01:4f9:1a:9494::2]:443/api/v1/check-in", host: "api.dev.ooni.io"
2024/06/05 09:11:34 [error] 89061#89061: *519456 upstream timed out (110: Unknown error) while connecting to upstream, client: 10.0.1.164, server: _, request: "POST /api/v1/check-in HTTP/1.1", upstream: "https://[2a01:4f9:1a:9494::2]:443/api/v1/check-in", host: "api.dev.ooni.io"
```
To this end, the diff here adds support for IPv6 `egress` traffic for the `nginx_sg` security group. 