### PR TITLE
Add support for setting up ansible-galaxy on the controller node

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,1 @@
+- src: willshersystems.sshd

--- a/ansible/roles/ansible_controller/tasks/main.yml
+++ b/ansible/roles/ansible_controller/tasks/main.yml
@@ -43,8 +43,6 @@
 - name: Install ansible galaxy dependencies
   become: yes
   become_user: ubuntu
-  vars:
-    allow_world_readable_tmpfiles: true
   ansible.builtin.shell:
     cmd: ansible-galaxy install -r requirements.yml
     chdir: /srv/devops/ansible

--- a/ansible/roles/ansible_controller/tasks/main.yml
+++ b/ansible/roles/ansible_controller/tasks/main.yml
@@ -9,7 +9,6 @@
       - "python3-boto3"
       - "tmux"
       - "vim"
-      - "acl"
     state: "latest"
     update_cache: "yes"
 
@@ -44,7 +43,7 @@
   become: yes
   become_user: ubuntu
   ansible.builtin.shell:
-    cmd: ansible-galaxy install -r requirements.yml
+    cmd: ansible-galaxy install -p /etc/ansible/roles -r requirements.yml
     chdir: /srv/devops/ansible
 
 - name: set global gitconfig for each user

--- a/ansible/roles/ansible_controller/tasks/main.yml
+++ b/ansible/roles/ansible_controller/tasks/main.yml
@@ -16,6 +16,15 @@
   ansible.builtin.hostname:
     name: "ansible-controller"
 
+- name: create ansible roles directory
+  ansible.builtin.file:
+    state: directory
+    path: /etc/ansible/roles
+    recurse: yes
+    owner: ubuntu
+    group: admin
+    mode: "u=rwX,g=rwX,o=r"
+
 - name: clone devops repo into /srv/devops
   ansible.builtin.git:
     repo: "https://github.com/ooni/devops.git"
@@ -29,6 +38,13 @@
     owner: ubuntu
     group: admin
     mode: "u=rwX,g=rwX,o=r"
+
+- name: Install ansible galaxy dependencies
+  become: yes
+  become_user: ubuntu
+  ansible.builtin.shell:
+    cmd: ansible-galaxy install -r requirements.yml
+    chdir: /srv/devops/ansible
 
 - name: set global gitconfig for each user
   ansible.builtin.copy:

--- a/ansible/roles/ansible_controller/tasks/main.yml
+++ b/ansible/roles/ansible_controller/tasks/main.yml
@@ -43,6 +43,8 @@
 - name: Install ansible galaxy dependencies
   become: yes
   become_user: ubuntu
+  vars:
+    allow_world_readable_tmpfiles: true
   ansible.builtin.shell:
     cmd: ansible-galaxy install -r requirements.yml
     chdir: /srv/devops/ansible

--- a/ansible/roles/ansible_controller/tasks/main.yml
+++ b/ansible/roles/ansible_controller/tasks/main.yml
@@ -9,6 +9,7 @@
       - "python3-boto3"
       - "tmux"
       - "vim"
+      - "acl"
     state: "latest"
     update_cache: "yes"
 


### PR DESCRIPTION
This is part of the work being done in: https://github.com/ooni/devops/issues/27

It adds support for ansible-galaxy so we can use the sshd_user galaxy module to unify sshd configuration and ensure all users have access to all hosts