### PR TITLE
feat: use galaxy module to configure sshd

### DIFF
--- a/ansible/roles/ssh_users/tasks/main.yml
+++ b/ansible/roles/ssh_users/tasks/main.yml
@@ -73,3 +73,9 @@
   ansible.builtin.file:
     path: /etc/sudoers.d/adm
     state: absent
+
+- name: configure sshd
+  include_role: willshersystems.ssh
+  vars:
+    AllowUsers: "{{item}}"
+  with_items: "{{ admin_usernames | union(non_admin_usernames) }}"


### PR DESCRIPTION
This is part of the work being done in #27. 

This diff adds support for using the ansible galaxy module ((ansible-sshd){https://github.com/willshersystems/ansible-sshd}) to configure sshd on the ansible-controller and other hosts (all hosts using the `ssh_users` role)