### PR TITLE
fix(scripts): add missing tags column while migrating

### DIFF
--- a/scripts/migrate-oonifindings.py
+++ b/scripts/migrate-oonifindings.py
@@ -43,6 +43,7 @@ def dump_oonifindings_clickhouse():
             "deleted": d["deleted"],
             "email_address": d["email_address"],
             "country_codes": json.dumps(d["CCs"]),
+            "tags": json.dumps(d["tags"]),
             "asns": json.dumps(d["ASNs"]),
             "domains": json.dumps(d["domains"]),
             "links": json.dumps(d["links"]),


### PR DESCRIPTION
We were missing a `tags` column which led to a pydantic validation error in the API. This should be resolved here.