### PR TITLE
refactor: remove individual load balancers from services

### DIFF
--- a/tf/modules/ooniapi_service/main.tf
+++ b/tf/modules/ooniapi_service/main.tf
@@ -131,10 +131,6 @@ resource "aws_ecs_service" "ooniapi_service" {
     container_port   = "80"
   }
 
-  depends_on = [
-    aws_alb_listener.ooniapi_service_http,
-  ]
-
   force_new_deployment = true
 
   tags = var.tags
@@ -168,88 +164,4 @@ resource "aws_alb_target_group" "ooniapi_service_mapped" {
   }
 
   tags = var.tags
-}
-
-resource "aws_alb" "ooniapi_service" {
-  name            = local.name
-  subnets         = var.public_subnet_ids
-  security_groups = var.ooniapi_service_security_groups
-
-  tags = var.tags
-}
-
-resource "aws_alb_listener" "ooniapi_service_http" {
-  load_balancer_arn = aws_alb.ooniapi_service.id
-  port              = "80"
-  protocol          = "HTTP"
-
-  default_action {
-    target_group_arn = aws_alb_target_group.ooniapi_service_direct.id
-    type             = "forward"
-  }
-
-  tags = var.tags
-}
-
-resource "aws_alb_listener" "front_end_https" {
-  load_balancer_arn = aws_alb.ooniapi_service.id
-  port              = "443"
-  protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = aws_acm_certificate.ooniapi_service.arn
-
-  default_action {
-    target_group_arn = aws_alb_target_group.ooniapi_service_direct.id
-    type             = "forward"
-  }
-
-  tags = var.tags
-}
-
-resource "aws_route53_record" "ooniapi_service" {
-  zone_id = var.dns_zone_ooni_io
-  name    = "${var.service_name}.api.${var.stage}.ooni.io"
-  type    = "A"
-
-  alias {
-    name                   = aws_alb.ooniapi_service.dns_name
-    zone_id                = aws_alb.ooniapi_service.zone_id
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_acm_certificate" "ooniapi_service" {
-  domain_name       = "${var.service_name}.api.${var.stage}.ooni.io"
-  validation_method = "DNS"
-
-  tags = var.tags
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_route53_record" "ooniapi_service_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.ooniapi_service.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
-
-  allow_overwrite = true
-  name            = each.value.name
-  records         = [each.value.record]
-  ttl             = 60
-  type            = each.value.type
-  zone_id         = var.dns_zone_ooni_io
-}
-
-resource "aws_acm_certificate_validation" "ooniapi_service" {
-  certificate_arn         = aws_acm_certificate.ooniapi_service.arn
-  validation_record_fqdns = [for record in aws_route53_record.ooniapi_service_validation : record.fqdn]
-  depends_on = [
-    aws_route53_record.ooniapi_service
-  ]
 }

--- a/tf/modules/ooniapi_service/outputs.tf
+++ b/tf/modules/ooniapi_service/outputs.tf
@@ -1,11 +1,3 @@
-output "ooni_io_fqdn" {
-  value = aws_route53_record.ooniapi_service.name
-}
-
-output "dns_name" {
-  value = aws_alb.ooniapi_service.dns_name
-}
-
 output "ecs_service_name" {
   value = aws_ecs_service.ooniapi_service.name
 }


### PR DESCRIPTION
This diff removes individual load balancers from the ooniapi services and only allows a single load balancer for routing based on api paths.