### PR TITLE
fix: remove microservice hosts from alerts

### DIFF
--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -99,9 +99,6 @@ scrape_configs:
       password: '{{ prometheus_metrics_password_dev }}'
     static_configs:
       - targets:
-        - ooniauth.api.dev.ooni.io
-        - oonirun.api.dev.ooni.io
-        - ooniprobe.api.dev.ooni.io
         - oohelperd.th.dev.ooni.io
 
   - job_name: 'ooniapi-services-prod'


### PR DESCRIPTION
This diff removes the microservice hosts from the prometheus alerts. Part of https://github.com/ooni/devops/issues/93