### PR TITLE
fix(prod): increase asg min capacity

### DIFF
--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -314,9 +314,9 @@ module "ooniapi_cluster" {
   subnet_ids = module.network.vpc_subnet_public[*].id
 
   # You need be careful how these are tweaked.
-  asg_min     = 3
+  asg_min     = 4
   asg_max     = 8
-  asg_desired = 3
+  asg_desired = 4
 
   instance_type = "t3.micro"
 


### PR DESCRIPTION
`api.ooni.org` gives us a `503` when calling the incidents service. On further inspection, it seems the redeployment of the findings service has been halted due to insufficient memory in the ecs infra setup. This diff increase the asg capacity to a minimum of 4 ec2 instances which should suffice for now.