### PR TITLE
refactor(prod): switch to using t3a.medium instances

### DIFF
--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -318,7 +318,7 @@ module "ooniapi_cluster" {
   asg_max     = 8
   asg_desired = 2
 
-  instance_type = "t4g.medium"
+  instance_type = "t3a.medium"
 
   tags = merge(
     local.tags,

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -314,11 +314,11 @@ module "ooniapi_cluster" {
   subnet_ids = module.network.vpc_subnet_public[*].id
 
   # You need be careful how these are tweaked.
-  asg_min     = 4
+  asg_min     = 2
   asg_max     = 8
-  asg_desired = 4
+  asg_desired = 2
 
-  instance_type = "t3.micro"
+  instance_type = "t4g.medium"
 
   tags = merge(
     local.tags,


### PR DESCRIPTION
It seems we are low on memory on our `t3.micro` instances leading to impending task deployments. This should scale our instances enough to allow running all service tasks for now. 