### PR TITLE
Rotate docker log files after 100MB

### DIFF
--- a/tf/modules/ooni_th_droplet/templates/cloud-init-docker.yml
+++ b/tf/modules/ooni_th_droplet/templates/cloud-init-docker.yml
@@ -103,7 +103,9 @@ write_files:
     content: |
       {
         "ipv6": true,
-        "fixed-cidr-v6": "2001:db8:1::/64"
+        "fixed-cidr-v6": "2001:db8:1::/64",
+        "log-driver": "json-file",
+        "log-opts": {"max-size": "100m", "max-file": "3"}
       }
 
   - path: /etc/nginx/sites-available/default


### PR DESCRIPTION
Test helpers were running out of disk space. This configuration was run manually, but we ought to at some point redeploy it on all hosts.