### PR TITLE
fix: forward X-Real-IP header

### DIFF
--- a/tf/modules/ooni_backendproxy/templates/cloud-init.yml
+++ b/tf/modules/ooni_backendproxy/templates/cloud-init.yml
@@ -16,6 +16,8 @@ write_files:
           proxy_pass ${backend_url};
           proxy_http_version 1.1;
           proxy_set_header Host \$host;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Real-IP $http_x_forwarded_for;
         }
         error_log /var/log/nginx/error.log;
       }


### PR DESCRIPTION
The OONI API seems to be returning `429` for several requests. It seems we do not forward the `X-Real-Ip` header used for ratelimiting: https://github.com/ooni/backend/blob/master/api/ooniapi/rate_limit_quotas.py#L98. This allows us to set the `X-Real-IP` http header in the backend-proxy and forward it to the service running host.