### PR TITLE
refactor: drop monitoring for db1 and amsmatomo

### DIFF
--- a/ansible/roles/prometheus/vars/main.yml
+++ b/ansible/roles/prometheus/vars/main.yml
@@ -1,8 +1,6 @@
 dom0_hosts:
   - ams-ps.ooni.nu
   - ams-slack-1.ooni.org
-  - amsmatomo.ooni.nu
-  - db-1.proteus.ooni.io
   - doams1-countly.ooni.nu
   - mia-echoth.ooni.nu
   - mia-httpth.ooni.nu


### PR DESCRIPTION
We killed `db-1.proteus.ooni.io` and `amsmatomo.ooni.nu`. We can therefore, drop them from monitoring.