### PR TITLE
Add new jwt_secret for ooniprobe service

### DIFF
--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -188,6 +188,10 @@ data "aws_ssm_parameter" "jwt_secret" {
   name = "/oonidevops/secrets/ooni_services/jwt_secret"
 }
 
+data "aws_ssm_parameter" "jwt_secret_ooniprobe" {
+  name = "/oonidevops/secrets/ooni_services/jwt_secret_ooniprobe"
+}
+
 resource "random_password" "prometheus_metrics_password" {
   length  = 32
   special = false
@@ -341,7 +345,7 @@ module "ooniapi_ooniprobe" {
 
   task_secrets = {
     POSTGRESQL_URL              = aws_secretsmanager_secret_version.oonipg_url.arn
-    JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret.arn
+    JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret_ooniprobe.arn
     PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
   }
 


### PR DESCRIPTION
This is related to this PR in backend: https://github.com/ooni/backend/pull/923

We have to add a new `jwt_secret` encryption key for ooniprobe, since the current ooniprobe service provides toy login tokens without authentication. If we don't use a different encryption key, you can get a session token from ooniprobe that can be used in ooniauth to login without authentication. 

**Note**: For this PR to work we have to create the key in Parameter Storage in AWS