### PR TITLE
Add missing region entries to .aws/credentials file`

### DIFF
--- a/tf/README.md
+++ b/tf/README.md
@@ -11,12 +11,15 @@ Terraform is used for managing the OONI infrastructure as code.
 [oonidevops_user]
 aws_access_key_id = YYYY
 aws_secret_access_key = ZZZ
+region = eu-central-1
 [oonidevops_user_dev]
 role_arn = arn:aws:iam::905418398257:role/oonidevops
 source_profile = oonidevops_user
+region = eu-central-1
 [oonidevops_user_prod]
 role_arn = arn:aws:iam::471112720364:role/oonidevops
 source_profile = oonidevops_user
+region = eu-central-1
 ```
 
 Where you replace OONI_ORG_ID with the ID of the ORG you are deploying to (dev,


### PR DESCRIPTION
I had an error trying to run an ansible playbook because of a configuration error with AWS, and we solved it by adding the region field in all entries of the credentials file.

Trying to run 
```
./play -i inventory deploy-monitoring.yml -l monitoring.ooni.org --diff --check
```
I got 

```
You must specify a region. You can also configure your region by running "aws configure".
[WARNING]: Error in vault password file loading (default): Vault password script
/home/luis/Dev/ooni/devops/ansible/password-pipe returned non-zero (253): None
ERROR! Vault password script /home/luis/Dev/ooni/devops/ansible/password-pipe returned non-zero (253): None
(ooni) ➜  ansible git:(password-pipe-aws)
```

I followed the "run aws configure" advice in the message but it also didn't work.

Adding the region field to every entry in ~/.aws/credentials fixed the problem 