### PR TITLE
Node exporter ecs monitoring

### DIFF
--- a/ansible/deploy-clickhouse-proxy.yml
+++ b/ansible/deploy-clickhouse-proxy.yml
@@ -3,6 +3,28 @@
   hosts:
     - clickhouseproxy.dev.ooni.io
   become: true
+  pre_tasks: 
+  - name: Create node exporter user
+    user:
+      name: node_exporter
+      state: present
+      shell: /sbin/nologin
+      system: true
+  #   # required by node exporter, see: 
+  #   TODO: Create the certificate for node exporter
+  #   # https://galaxy.ansible.com/ui/repo/published/prometheus/prometheus/content/role/node_exporter/
+  #   - name: Create node_exporter cert dir 
+  #     file: 
+  #       path: "/etc/node_exporter"
+  #       state: directory
+  #       owner: root
+  #       group: root
+  #   - name: Create cert and key for node exporter
+  #     openssl_certificate:
+  #       path: /etc/node_exporter/tls.cert
+  #       csr_path: /etc/node_exporter/tls.csr
+  #       privatekey_path: /etc/node_exporter/tls.key
+  #       provider: selfsigned
   roles:
     - role: bootstrap
     - role: nginx
@@ -11,3 +33,10 @@
       vars: 
         clickhouse_url: "clickhouse3.prod.ooni.io"
         clickhouse_port: 9000
+    - role: prometheus.prometheus.node_exporter
+      vars:
+        node_exporter_system_user: node_exporter
+        node_exporter_system_group: node_exporter
+      #   node_exporter_tls_server_config:
+      #     cert_file: /etc/node_exporter/tls.cert
+      #     key_file: /etc/node_exporter/tls.key

--- a/ansible/deploy-clickhouse-proxy.yml
+++ b/ansible/deploy-clickhouse-proxy.yml
@@ -3,27 +3,6 @@
   hosts:
     - clickhouseproxy.dev.ooni.io
   become: true
-  pre_tasks: 
-  - name: Create node exporter user
-    user:
-      name: node_exporter
-      state: present
-      shell: /sbin/nologin
-      system: true
-  #   # required by node exporter, see: 
-  #   # https://galaxy.ansible.com/ui/repo/published/prometheus/prometheus/content/role/node_exporter/
-  #   - name: Create node_exporter cert dir 
-  #     file: 
-  #       path: "/etc/node_exporter"
-  #       state: directory
-  #       owner: root
-  #       group: root
-  #   - name: Create cert and key for node exporter
-  #     openssl_certificate:
-  #       path: /etc/node_exporter/tls.cert
-  #       csr_path: /etc/node_exporter/tls.csr
-  #       privatekey_path: /etc/node_exporter/tls.key
-  #       provider: selfsigned
   roles:
     - role: bootstrap
     - role: nginx
@@ -32,10 +11,13 @@
       vars: 
         clickhouse_url: "clickhouse3.prod.ooni.io"
         clickhouse_port: 9000
-    - role: prometheus.prometheus.node_exporter
+    - role: dehydrated
       vars:
-        node_exporter_system_user: node_exporter
-        node_exporter_system_user: node_exporter
-      #   node_exporter_tls_server_config:
-      #     cert_file: /etc/node_exporter/tls.cert
-      #     key_file: /etc/node_exporter/tls.key
+        ssl_domains: "clickhouseproxy.dev.ooni.io"
+        tls_cert_dir: /var/lib/dehydrated/certs
+    - role: prometheus_node_exporter
+      vars:
+        node_exporter_port: 9100
+        prometheus_nginx_proxy_config: 
+          - location: /metrics/node_exporter
+            proxy_pass: http://127.0.0.1:9100/metrics

--- a/ansible/deploy-clickhouse-proxy.yml
+++ b/ansible/deploy-clickhouse-proxy.yml
@@ -11,7 +11,6 @@
       shell: /sbin/nologin
       system: true
   #   # required by node exporter, see: 
-  #   TODO: Create the certificate for node exporter
   #   # https://galaxy.ansible.com/ui/repo/published/prometheus/prometheus/content/role/node_exporter/
   #   - name: Create node_exporter cert dir 
   #     file: 
@@ -36,7 +35,7 @@
     - role: prometheus.prometheus.node_exporter
       vars:
         node_exporter_system_user: node_exporter
-        node_exporter_system_group: node_exporter
+        node_exporter_system_user: node_exporter
       #   node_exporter_tls_server_config:
       #     cert_file: /etc/node_exporter/tls.cert
       #     key_file: /etc/node_exporter/tls.key

--- a/ansible/requirements/ansible-galaxy.yml
+++ b/ansible/requirements/ansible-galaxy.yml
@@ -1,19 +1,15 @@
-roles:
-  - src: willshersystems.sshd
-    version: v0.25.0
-  - src: nginxinc.nginx
-    version: 0.24.3
-  - src: geerlingguy.certbot
-    version: 5.2.0
-  - src: artis3n.tailscale
-    version: v4.5.0
-  - src: https://github.com/idealista/clickhouse_role
-    scm: git
-    version: 3.5.1
-    name: idealista.clickhouse_role
-  - src: https://github.com/ooni/airflow-role.git
-    scm: git
-    name: ooni.airflow_role
-collections: 
-  - name: prometheus.prometheus
-    version: 0.24.1
+- src: willshersystems.sshd
+  version: v0.25.0
+- src: nginxinc.nginx
+  version: 0.24.3
+- src: geerlingguy.certbot
+  version: 5.2.0
+- src: artis3n.tailscale
+  version: v4.5.0
+- src: https://github.com/idealista/clickhouse_role
+  scm: git
+  version: 3.5.1
+  name: idealista.clickhouse_role
+- src: https://github.com/ooni/airflow-role.git
+  scm: git
+  name: ooni.airflow_role

--- a/ansible/requirements/ansible-galaxy.yml
+++ b/ansible/requirements/ansible-galaxy.yml
@@ -1,15 +1,19 @@
-- src: willshersystems.sshd
-  version: v0.25.0
-- src: nginxinc.nginx
-  version: 0.24.3
-- src: geerlingguy.certbot
-  version: 5.2.0
-- src: artis3n.tailscale
-  version: v4.5.0
-- src: https://github.com/idealista/clickhouse_role
-  scm: git
-  version: 3.5.1
-  name: idealista.clickhouse_role
-- src: https://github.com/ooni/airflow-role.git
-  scm: git
-  name: ooni.airflow_role
+roles:
+  - src: willshersystems.sshd
+    version: v0.25.0
+  - src: nginxinc.nginx
+    version: 0.24.3
+  - src: geerlingguy.certbot
+    version: 5.2.0
+  - src: artis3n.tailscale
+    version: v4.5.0
+  - src: https://github.com/idealista/clickhouse_role
+    scm: git
+    version: 3.5.1
+    name: idealista.clickhouse_role
+  - src: https://github.com/ooni/airflow-role.git
+    scm: git
+    name: ooni.airflow_role
+collections: 
+  - name: prometheus.prometheus
+    version: 0.24.1

--- a/tf/modules/ecs_cluster/main.tf
+++ b/tf/modules/ecs_cluster/main.tf
@@ -145,6 +145,7 @@ resource "aws_launch_template" "container_host" {
   user_data = base64encode(templatefile("${path.module}/templates/ecs-setup.sh", {
     ecs_cluster_name = var.name,
     ecs_cluster_tags = var.tags
+    node_exporter_port = var.node_exporter_port
   }))
 
   update_default_version               = true

--- a/tf/modules/ecs_cluster/templates/ecs-setup.sh
+++ b/tf/modules/ecs_cluster/templates/ecs-setup.sh
@@ -7,6 +7,9 @@ ECS_CONTAINER_INSTANCE_TAGS=${jsonencode(ecs_cluster_tags)}
 ECS_ENABLE_TASK_IAM_ROLE=true
 EOF
 
+# Exit on error and show running commands
+set -ex
+
 # Install node exporter on this machine
 # IN CASE OF UPDATE: You can find this downloads and its checksums here: 
 # https://prometheus.io/download/#node_exporter

--- a/tf/modules/ecs_cluster/templates/ecs-setup.sh
+++ b/tf/modules/ecs_cluster/templates/ecs-setup.sh
@@ -7,3 +7,42 @@ ECS_CONTAINER_INSTANCE_TAGS=${jsonencode(ecs_cluster_tags)}
 ECS_ENABLE_TASK_IAM_ROLE=true
 EOF
 
+# Install node exporter on this machine
+DOWNLOAD_LINK='https://github.com/prometheus/node_exporter/releases/download/v1.8.2/node_exporter-1.8.2.linux-amd64.tar.gz'
+CHECKSUM='6809dd0b3ec45fd6e992c19071d6b5253aed3ead7bf0686885a51d85c6643c66'
+# TODO Checksum this file
+
+# Download node exporter binary
+echo "Downloading node exporter..."
+cd /tmp
+curl -O -L $DOWNLOAD_LINK
+tar xvfz node_exporter-*.*-amd64.tar.gz
+sudo mv node_exporter-*.*-amd64/node_exporter /usr/local/bin/
+
+
+# Add node exporter service user
+echo "Creating node exporter user..."
+sudo useradd -rs /bin/false node_exporter
+
+# Create service file for node exporter
+echo "Setting up service file..."
+cat <<'EOF' >> /tmp/node_exporter.service
+[Unit]
+Description=Node Exporter
+After=network.target
+[Service]
+User=node_exporter
+Group=node_exporter
+Type=simple
+ExecStart=/usr/local/bin/node_exporter
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo mv /tmp/node_exporter.service /etc/systemd/system
+
+# update systemd
+echo "Updating systemd..."
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter

--- a/tf/modules/ecs_cluster/templates/ecs-setup.sh
+++ b/tf/modules/ecs_cluster/templates/ecs-setup.sh
@@ -35,6 +35,8 @@ fi
 tar xvfz node_exporter-*.*-amd64.tar.gz
 chmod 555 node_exporter-*.*-amd64/node_exporter
 sudo mv node_exporter-*.*-amd64/node_exporter /usr/local/bin/
+# Delete remaning files
+rm -r node_exporter-*.*-amd64 node_exporter-*.*-amd64.tar.gz
 
 
 # Add node exporter service user

--- a/tf/modules/ecs_cluster/templates/ecs-setup.sh
+++ b/tf/modules/ecs_cluster/templates/ecs-setup.sh
@@ -8,6 +8,8 @@ ECS_ENABLE_TASK_IAM_ROLE=true
 EOF
 
 # Install node exporter on this machine
+# IN CASE OF UPDATE: You can find this downloads and its checksums here: 
+# https://prometheus.io/download/#node_exporter
 DOWNLOAD_LINK='https://github.com/prometheus/node_exporter/releases/download/v1.8.2/node_exporter-1.8.2.linux-amd64.tar.gz'
 CHECKSUM='6809dd0b3ec45fd6e992c19071d6b5253aed3ead7bf0686885a51d85c6643c66'
 

--- a/tf/modules/ecs_cluster/templates/ecs-setup.sh
+++ b/tf/modules/ecs_cluster/templates/ecs-setup.sh
@@ -51,7 +51,8 @@ After=network.target
 User=node_exporter
 Group=node_exporter
 Type=simple
-ExecStart=/usr/local/bin/node_exporter
+ExecStart=/usr/local/bin/node_exporter --web.listen-address=:${node_exporter_port}
+Restart=always
 [Install]
 WantedBy=multi-user.target
 EOF

--- a/tf/modules/ecs_cluster/templates/ecs-setup.sh
+++ b/tf/modules/ecs_cluster/templates/ecs-setup.sh
@@ -33,6 +33,7 @@ fi
 
 # Move it to an executable path
 tar xvfz node_exporter-*.*-amd64.tar.gz
+chmod 555 node_exporter-*.*-amd64/node_exporter
 sudo mv node_exporter-*.*-amd64/node_exporter /usr/local/bin/
 
 

--- a/tf/modules/ecs_cluster/templates/ecs-setup.sh
+++ b/tf/modules/ecs_cluster/templates/ecs-setup.sh
@@ -10,12 +10,23 @@ EOF
 # Install node exporter on this machine
 DOWNLOAD_LINK='https://github.com/prometheus/node_exporter/releases/download/v1.8.2/node_exporter-1.8.2.linux-amd64.tar.gz'
 CHECKSUM='6809dd0b3ec45fd6e992c19071d6b5253aed3ead7bf0686885a51d85c6643c66'
-# TODO Checksum this file
 
 # Download node exporter binary
 echo "Downloading node exporter..."
 cd /tmp
 curl -O -L $DOWNLOAD_LINK
+
+# Checksum the file
+ACTUAL_FILE=$(ls | grep node_exporter-*.*-amd64.tar.gz)
+echo "$CHECKSUM $ACTUAL_FILE" | sha256sum -c -
+if [[ $? -eq 0 ]]; then
+    echo "Node exporter checksum validation OK!"
+else
+    echo "[ERROR] Checksum validation for node exporter failed!" >&2
+    exit 1
+fi
+
+# Move it to an executable path
 tar xvfz node_exporter-*.*-amd64.tar.gz
 sudo mv node_exporter-*.*-amd64/node_exporter /usr/local/bin/
 

--- a/tf/modules/ecs_cluster/variables.tf
+++ b/tf/modules/ecs_cluster/variables.tf
@@ -61,3 +61,7 @@ variable "instance_type" {
 variable "instance_volume_size" {
   default = "5"
 }
+
+variable "node_exporter_port" {
+  default = "9100"
+}


### PR DESCRIPTION
This PR adds the node exporter service to ECS cluster machines. This is necessary for #178  (and therefore for #104).

Node exporter is installed with the user-data script that initializes cluster machines 
