### PR TITLE
Add path patterns in load balancer for ooniprobe service

### DIFF
--- a/tf/modules/ooniapi_frontend/main.tf
+++ b/tf/modules/ooniapi_frontend/main.tf
@@ -148,6 +148,9 @@ resource "aws_lb_listener_rule" "ooniapi_ooniprobe_rule" {
     path_pattern {
       values = [
         "/api/v2/ooniprobe/*",
+        "/api/v1/login",
+        "/api/v1/register",
+        "/api/v1/update/*"
       ]
     }
   }


### PR DESCRIPTION
Adds load balancer configuration to add probe services to the API in `api.ooni.org`

Includes `/register`, `/update` and `/login`

This PR solves #180 