### PR TITLE
Add ams-ps to allow list for pg

### DIFF
--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -172,7 +172,9 @@ module "oonipg" {
   allow_cidr_blocks     = [
     "10.0.0.0/8",
     # airflow host
-    "142.132.254.225/32"
+    "142.132.254.225/32",
+    # ams-ps
+    "37.218.245.90/32"
   ]
   allow_security_groups = []
 


### PR DESCRIPTION
Fix access control to pg host to allow ams-ps access.

This had been broken since ~16th of January, leading to tests requiring test targets failing (eg. tor), see: https://explorer.ooni.org/chart/mat?test_name=tor&axis_x=measurement_start_day&since=2024-12-03&until=2025-02-16&time_grain=day