### PR TITLE
refactor: switch to using new jwt token for ooniprobe

### DIFF
--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -444,7 +444,7 @@ module "ooniapi_ooniprobe" {
 
   task_secrets = {
     POSTGRESQL_URL              = data.aws_ssm_parameter.oonipg_url.arn
-    JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret_legacy.arn
+    JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret.arn
     PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
   }
 


### PR DESCRIPTION
This reverts the prod changes done in #185. We have since then decided to try switching to the newer jwt token and serving test-lists directly from backend-fsn.