### PR TITLE
Use the same password for both dev and prod /metrics 

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -43,4 +43,4 @@ admin_usernames: [art, mehul, luis, hynnot]
 root_usernames: [art, mehul, luis, hynnot]
 non_admin_usernames: []
 
-prometheus_metrics_password: "{{ lookup('amazon.aws.aws_secret', 'oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_prod') }}"
+prometheus_metrics_password: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_prod') }}"

--- a/ansible/group_vars/dev/vars.yml
+++ b/ansible/group_vars/dev/vars.yml
@@ -1,3 +1,3 @@
-prometheus_metrics_password: "{{ lookup('amazon.aws.aws_secret', 'oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_dev') }}"
+prometheus_metrics_password: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_dev') }}"
 admin_usernames: [ art, mehul, norbel, majakomel ]
 non_admin_usernames: [ agrabeli ]

--- a/ansible/group_vars/prod/vars.yml
+++ b/ansible/group_vars/prod/vars.yml
@@ -1,4 +1,4 @@
-prometheus_metrics_password: "{{ lookup('amazon.aws.aws_secret', 'oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_prod') }}"
+prometheus_metrics_password: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_prod') }}"
 tailscale_authkey: "{{ lookup('amazon.aws.aws_secret', 'oonidevops/tailscale_authkey_devops', profile='oonidevops_user_prod') }}"
 tailscale_tags:
   - "devops-prod"

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -31,5 +31,5 @@
     - prometheus
     - config
   vars:
-    prometheus_metrics_password_dev: "{{ lookup('amazon.aws.aws_secret', 'oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_dev') }}"
-    prometheus_metrics_password_prod: "{{ lookup('amazon.aws.aws_secret', 'oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_prod') }}"
+    prometheus_metrics_password_dev: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_dev') }}"
+    prometheus_metrics_password_prod: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_prod') }}"

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -31,5 +31,4 @@
     - prometheus
     - config
   vars:
-    prometheus_metrics_password_dev: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_dev') }}"
-    prometheus_metrics_password_prod: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_prod') }}"
+    prometheus_metrics_password: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/ooni_services/prometheus_metrics_password', profile='oonidevops_user_dev') }}"

--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -65,7 +65,7 @@ scrape_configs:
     scrape_interval: 5s
     basic_auth:
       username: 'prom'
-      password: '{{ prometheus_metrics_password_prod }}'
+      password: '{{ prometheus_metrics_password }}'
     static_configs:
       - targets:
         - https://data1.htz-fsn.prod.ooni.nu/metrics/node_exporter
@@ -135,7 +135,7 @@ scrape_configs:
     metrics_path: "/metrics/clickhouse"
     basic_auth:
       username: 'prom'
-      password: '{{ prometheus_metrics_password_prod }}'
+      password: '{{ prometheus_metrics_password }}'
     static_configs:
       - targets:
         - data1.htz-fsn.prod.ooni.nu
@@ -165,7 +165,7 @@ scrape_configs:
     metrics_path: "/metrics"
     basic_auth:
       username: 'prom'
-      password: '{{ prometheus_metrics_password_prod }}'
+      password: '{{ prometheus_metrics_password }}'
     static_configs:
       - targets:
         - ooniauth.prod.ooni.io
@@ -188,7 +188,7 @@ scrape_configs:
     metrics_path: "/metrics"
     basic_auth:
       username: 'prom'
-      password: '{{ prometheus_metrics_password_prod }}'
+      password: '{{ prometheus_metrics_password }}'
     static_configs:
       - targets:
         - 0.do.th.prod.ooni.io
@@ -255,7 +255,7 @@ scrape_configs:
     scheme: https
     basic_auth:
       username: 'prom'
-      password: '{{ prometheus_metrics_password_dev }}'
+      password: '{{ prometheus_metrics_password }}'
     file_sd_configs:
       - files: 
         - '/var/lib/prometheus/file_discovery/*.json'

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -196,23 +196,9 @@ data "aws_ssm_parameter" "oonipg_url" {
   name = "/oonidevops/secrets/ooni-tier0-postgres/postgresql_write_url"
 }
 
-resource "random_password" "prometheus_metrics_password" {
-  length  = 32
-  special = false
-}
-
-resource "aws_secretsmanager_secret" "prometheus_metrics_password" {
-  name = "oonidevops/ooni_services/prometheus_metrics_password"
-  tags = local.tags
-}
-
-resource "aws_secretsmanager_secret_version" "prometheus_metrics_password" {
-  secret_id     = aws_secretsmanager_secret.prometheus_metrics_password.id
-  secret_string = random_password.prometheus_metrics_password.result
-}
-
-data "aws_secretsmanager_secret_version" "prometheus_metrics_password" {
-  secret_id = aws_secretsmanager_secret.prometheus_metrics_password.id
+# Manually managed with the AWS console
+data "aws_ssm_parameter" "prometheus_metrics_password" {
+  name = "/oonidevops/ooni_services/prometheus_metrics_password"
 }
 
 resource "aws_secretsmanager_secret" "oonipg_url" {
@@ -281,7 +267,7 @@ module "ooni_th_droplet" {
   instance_size     = "s-1vcpu-1gb"
   droplet_count     = 1
   deployer_key      = jsondecode(data.aws_secretsmanager_secret_version.deploy_key.secret_string)["public_key"]
-  metrics_password  = data.aws_secretsmanager_secret_version.prometheus_metrics_password.secret_string
+  metrics_password  = data.aws_ssm_parameter.prometheus_metrics_password.arn
   ssh_keys = [
     "3d:81:99:17:b5:d1:20:a5:fe:2b:14:96:67:93:d6:34",
     "f6:4b:8b:e2:0e:d2:97:c5:45:5c:07:a6:fe:54:60:0e"
@@ -357,7 +343,7 @@ module "ooniapi_ooniprobe" {
   task_secrets = {
     POSTGRESQL_URL              = data.aws_ssm_parameter.oonipg_url.arn
     JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret_legacy.arn
-    PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
+    PROMETHEUS_METRICS_PASSWORD = data.aws_ssm_parameter.prometheus_metrics_password.arn
   }
 
   ooniapi_service_security_groups = [
@@ -405,7 +391,7 @@ module "ooniapi_reverseproxy" {
   ecs_cluster_id           = module.ooniapi_cluster.cluster_id
 
   task_secrets = {
-    PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
+    PROMETHEUS_METRICS_PASSWORD = data.aws_ssm_parameter.prometheus_metrics_password.arn
   }
 
   task_environment = {
@@ -529,7 +515,7 @@ module "ooniapi_oonirun" {
   task_secrets = {
     POSTGRESQL_URL              = data.aws_ssm_parameter.oonipg_url.arn
     JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret.arn
-    PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
+    PROMETHEUS_METRICS_PASSWORD = data.aws_ssm_parameter.prometheus_metrics_password.arn
   }
 
   ooniapi_service_security_groups = [
@@ -577,7 +563,7 @@ module "ooniapi_oonifindings" {
   task_secrets = {
     POSTGRESQL_URL              = data.aws_ssm_parameter.oonipg_url.arn
     JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret.arn
-    PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
+    PROMETHEUS_METRICS_PASSWORD = data.aws_ssm_parameter.prometheus_metrics_password.arn
     CLICKHOUSE_URL              = data.aws_ssm_parameter.clickhouse_readonly_url.arn
   }
 
@@ -626,7 +612,7 @@ module "ooniapi_ooniauth" {
   task_secrets = {
     POSTGRESQL_URL              = data.aws_ssm_parameter.oonipg_url.arn
     JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret.arn
-    PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
+    PROMETHEUS_METRICS_PASSWORD = data.aws_ssm_parameter.prometheus_metrics_password.arn
 
     AWS_SECRET_ACCESS_KEY = module.ooniapi_user.aws_secret_access_key_arn
     AWS_ACCESS_KEY_ID     = module.ooniapi_user.aws_access_key_id_arn
@@ -693,7 +679,7 @@ module "ooniapi_oonimeasurements" {
   task_secrets = {
     POSTGRESQL_URL              = data.aws_ssm_parameter.oonipg_url.arn
     JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret.arn
-    PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
+    PROMETHEUS_METRICS_PASSWORD = data.aws_ssm_parameter.prometheus_metrics_password.arn
     CLICKHOUSE_URL              = data.aws_ssm_parameter.clickhouse_readonly_url.arn
   }
 

--- a/tf/environments/prod/.terraform.lock.hcl
+++ b/tf/environments/prod/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/digitalocean/digitalocean" {
   version     = "2.43.0"
   constraints = "~> 2.0"
   hashes = [
+    "h1:9bQ4VyiF3oIjIgHxTXDVIWojoLYhCFwiqCLTZEsyVmA=",
     "h1:NFD+iFS14S3EILq2ZJ8bHaQGetYEAnETqEjkhl52eiI=",
     "zh:0023fa4ca4304e9141357df9dafff3bdb33f0189d0c8544f8b872070660ccb0e",
     "zh:4004c3034197ca6a2d719d26125eb21e01e652dc77932e27fd0c60151d7ca6d1",
@@ -30,6 +31,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 4.9.0, >= 4.66.1"
   hashes = [
     "h1:1R08bG9RT1qWHU6K0B992s3VbTIdb7cWt421+TBVS/8=",
+    "h1:36n0sS0B/ZL0yr4JsW07TT+WtLmozvlKTAA/MQWpDY8=",
     "zh:01b01b132b70df918f735898f1ad012ab3033d1b909b2e38950d16964d94c084",
     "zh:28bc6ee7b0c88b1a48f315509ad390fb1e8f39bebe0f7a43c22b1a63825251d1",
     "zh:31f9043a4c3538883ab9b9d3b399dae62e4552251e6a2b1da13ec3a2018a027d",
@@ -51,6 +53,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/cloudinit" {
   version = "2.3.5"
   hashes = [
+    "h1:HCoabXm6NQwCivl1q24+l9VUufc2mFqNeulsQBA9iFg=",
     "h1:Sf1Lt21oTADbzsnlU38ylpkl8YXP0Beznjcy5F/Yx64=",
     "zh:17c20574de8eb925b0091c9b6a4d859e9d6e399cd890b44cfbc028f4f312ac7a",
     "zh:348664d9a900f7baf7b091cf94d657e4c968b240d31d9e162086724e6afc19d5",
@@ -72,6 +75,7 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = ">= 2.0.0"
   hashes = [
     "h1:IyFbOIO6mhikFNL/2h1iZJ6kyN3U00jgkpCLUCThAfE=",
+    "h1:JlMZD6nYqJ8sSrFfEAH0Vk/SL8WLZRmFaMUF9PJK5wM=",
     "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
     "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
     "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
@@ -90,6 +94,7 @@ provider "registry.terraform.io/hashicorp/local" {
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.3"
   hashes = [
+    "h1:+AnORRgFbRO6qqcfaQyeX80W0eX3VmjadjnUFUJTiXo=",
     "h1:I0Um8UkrMUb81Fxq/dxbr3HLP2cecTH2WMJiwKSrwQY=",
     "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
     "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",
@@ -109,6 +114,7 @@ provider "registry.terraform.io/hashicorp/null" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.3"
   hashes = [
+    "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
     "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
     "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
@@ -129,6 +135,7 @@ provider "registry.terraform.io/hashicorp/time" {
   version     = "0.12.1"
   constraints = ">= 0.7.1"
   hashes = [
+    "h1:6BhxSYBJdBBKyuqatOGkuPKVenfx6UmLdiI13Pb3his=",
     "h1:JzYsPugN8Fb7C4NlfLoFu7BBPuRVT2/fCOdCaxshveI=",
     "zh:090023137df8effe8804e81c65f636dadf8f9d35b79c3afff282d39367ba44b2",
     "zh:26f1e458358ba55f6558613f1427dcfa6ae2be5119b722d0b3adb27cd001efea",
@@ -148,6 +155,7 @@ provider "registry.terraform.io/hashicorp/time" {
 provider "registry.terraform.io/hashicorp/tls" {
   version = "4.0.6"
   hashes = [
+    "h1:dYSb3V94K5dDMtrBRLPzBpkMTPn+3cXZ/kIJdtFL+2M=",
     "h1:n3M50qfWfRSpQV9Pwcvuse03pEizqrmYEryxKky4so4=",
     "zh:10de0d8af02f2e578101688fd334da3849f56ea91b0d9bd5b1f7a243417fdda8",
     "zh:37fc01f8b2bc9d5b055dc3e78bfd1beb7c42cfb776a4c81106e19c8911366297",

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -223,25 +223,6 @@ data "aws_ssm_parameter" "prometheus_metrics_password" {
   name = "/oonidevops/ooni_services/prometheus_metrics_password"
 }
 
-resource "random_password" "prometheus_metrics_password" {
-  length  = 32
-  special = false
-}
-
-resource "aws_secretsmanager_secret" "prometheus_metrics_password" {
-  name = "oonidevops/ooni_services/prometheus_metrics_password"
-  tags = local.tags
-}
-
-resource "aws_secretsmanager_secret_version" "prometheus_metrics_password" {
-  secret_id     = aws_secretsmanager_secret.prometheus_metrics_password.id
-  secret_string = random_password.prometheus_metrics_password.result
-}
-
-data "aws_secretsmanager_secret_version" "prometheus_metrics_password" {
-  secret_id = aws_secretsmanager_secret.prometheus_metrics_password.id
-}
-
 resource "aws_secretsmanager_secret" "oonipg_url" {
   name = "oonidevops/ooni-tier0-postgres/postgresql_url"
   tags = local.tags

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -218,6 +218,11 @@ data "aws_ssm_parameter" "oonipg_url" {
   name = "/oonidevops/secrets/ooni-tier0-postgres/postgresql_write_url"
 }
 
+# Manually managed with the AWS console
+data "aws_ssm_parameter" "prometheus_metrics_password" {
+  name = "/oonidevops/ooni_services/prometheus_metrics_password"
+}
+
 resource "random_password" "prometheus_metrics_password" {
   length  = 32
   special = false
@@ -299,7 +304,7 @@ module "ooni_th_droplet" {
   instance_size     = "s-1vcpu-1gb"
   droplet_count     = 3
   deployer_key      = jsondecode(data.aws_secretsmanager_secret_version.deploy_key.secret_string)["public_key"]
-  metrics_password  = data.aws_secretsmanager_secret_version.prometheus_metrics_password.secret_string
+  metrics_password  = data.aws_ssm_parameter.prometheus_metrics_password.arn
   ssh_keys = [
     "3d:81:99:17:b5:d1:20:a5:fe:2b:14:96:67:93:d6:34",
     "f6:4b:8b:e2:0e:d2:97:c5:45:5c:07:a6:fe:54:60:0e"
@@ -366,7 +371,7 @@ module "ooniapi_reverseproxy" {
   ecs_cluster_id           = module.ooniapi_cluster.cluster_id
 
   task_secrets = {
-    PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
+    PROMETHEUS_METRICS_PASSWORD = data.aws_ssm_parameter.prometheus_metrics_password.arn
   }
 
   task_environment = {
@@ -445,7 +450,7 @@ module "ooniapi_ooniprobe" {
   task_secrets = {
     POSTGRESQL_URL              = data.aws_ssm_parameter.oonipg_url.arn
     JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret_legacy.arn
-    PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
+    PROMETHEUS_METRICS_PASSWORD = data.aws_ssm_parameter.prometheus_metrics_password.arn
   }
 
   ooniapi_service_security_groups = [
@@ -494,7 +499,7 @@ module "ooniapi_oonirun" {
   task_secrets = {
     POSTGRESQL_URL              = data.aws_ssm_parameter.oonipg_url.arn
     JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret.arn
-    PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
+    PROMETHEUS_METRICS_PASSWORD = data.aws_ssm_parameter.prometheus_metrics_password.arn
   }
 
   ooniapi_service_security_groups = [
@@ -540,7 +545,7 @@ module "ooniapi_oonifindings" {
   task_secrets = {
     POSTGRESQL_URL              = data.aws_ssm_parameter.oonipg_url.arn
     JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret.arn
-    PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
+    PROMETHEUS_METRICS_PASSWORD = data.aws_ssm_parameter.prometheus_metrics_password.arn
   }
 
   ooniapi_service_security_groups = [
@@ -589,7 +594,7 @@ module "ooniapi_ooniauth" {
   task_secrets = {
     POSTGRESQL_URL              = data.aws_ssm_parameter.oonipg_url.arn
     JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret.arn
-    PROMETHEUS_METRICS_PASSWORD = aws_secretsmanager_secret_version.prometheus_metrics_password.arn
+    PROMETHEUS_METRICS_PASSWORD = data.aws_ssm_parameter.prometheus_metrics_password.arn
 
     AWS_SECRET_ACCESS_KEY = module.ooniapi_user.aws_secret_access_key_arn
     AWS_ACCESS_KEY_ID     = module.ooniapi_user.aws_access_key_id_arn


### PR DESCRIPTION
This PR will change the dev environment configuration to use the same password for /metrics in both prod and dev for ECS tasks

In order to do this we also changed the way the credentials are stored to use `aws_ssm` parameters instead of `secrets_manager` (also related to https://github.com/ooni/devops/issues/114)

Since this change was breaking the monitoring for several systems in prod that were using the old password, I used the old secrets manager password value for the new ssm manager password, meaning that a change in the secrets manager password can lead to breaking monitoring for some systems. 

For this reason, we should add a follow up issue to migrate all `prometheus_metrics_password` occurrences to use ssm and run that migration carefully to avoid disruptions in production

This PR solves https://github.com/ooni/devops/issues/187