### PR TITLE
Fix clickhouse proxy node exporter configuration

### DIFF
--- a/ansible/deploy-clickhouse-proxy.yml
+++ b/ansible/deploy-clickhouse-proxy.yml
@@ -23,6 +23,7 @@
     - role: prometheus_node_exporter
       vars:
         node_exporter_port: 9100
+        node_exporter_host: "0.0.0.0"
         prometheus_nginx_proxy_config: 
           - location: /metrics/node_exporter
             proxy_pass: http://127.0.0.1:9100/metrics


### PR DESCRIPTION
Change node exporter configuration for the clickhouse proxy Ansible playbook to listen to 0.0.0.0 instead of localhost

closes #203 