### PR TITLE
Point rev proxy deployer back to master

### DIFF
--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -363,7 +363,7 @@ module "ooniapi_reverseproxy_deployer" {
 
   service_name            = "reverseproxy"
   repo                    = "ooni/backend"
-  branch_name             = "add-prom-export-rev-proxy"
+  branch_name             = "master"
   buildspec_path          = "ooniapi/services/reverseproxy/buildspec.yml"
   codestar_connection_arn = aws_codestarconnections_connection.oonidevops.arn
 


### PR DESCRIPTION
Now that https://github.com/ooni/backend/pull/941 is merged, we can point this service back to master