### PR TITLE
Add job with prod version of ec2 instance scraping

### DIFF
--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -257,6 +257,10 @@ scrape_configs:
         replacement: "/$2"
         target_label: "__metrics_path__"
         action: "replace"
+      - source_labels: [job]
+        target_label: job
+        replacement: "ooni-aws-ec2"
+        action: "replace"
       - regex: "date_discovered"
         action: labeldrop
 

--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -225,6 +225,9 @@ scrape_configs:
         secret_key: "{{prometheus_aws_secret_key_dev}}"
         region: "eu-central-1"
         port: 9100  
+        filters:
+          - name: instance-state-name
+            values: ['running']
     relabel_configs: &ec2_relabeling # Change the host to the proxy host with relabeling
       - source_labels: [__meta_ec2_tag_Environment] # take environment from tags
         target_label: env

--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -220,8 +220,6 @@ scrape_configs:
     scrape_interval: 5s
     scheme: https 
     metrics_path: "/metrics" 
-
-    # Node level metrics for cluster nodes
     ec2_sd_configs:
       - access_key: "{{prometheus_aws_access_key_dev}}" 
         secret_key: "{{prometheus_aws_secret_key_dev}}"
@@ -240,7 +238,7 @@ scrape_configs:
         replacement: "{{clickhouse_proxy_host}}:9200/${1}/${2}/metrics"
         target_label: "__proxy_host"
         action: "replace"
-      - source_labels: [__proxy_host, env]
+      - source_labels: [__proxy_host, env] # Change ENV substr to value of env, find clickhouse proxy host
         separator: ";"
         regex: "([^;]*)ENV([^;]*);(.*)"
         replacement: "$1$3$2"
@@ -263,8 +261,6 @@ scrape_configs:
     scrape_interval: 5s
     scheme: https 
     metrics_path: "/metrics" 
-
-    # Node level metrics for cluster nodes
     ec2_sd_configs:
       - access_key: "{{prometheus_aws_access_key_prod}}" 
         secret_key: "{{prometheus_aws_secret_key_prod}}"
@@ -317,5 +313,4 @@ scrape_configs:
         action: "replace"
       - regex: "date_discovered"
         action: labeldrop
-
 ...

--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -226,8 +226,8 @@ scrape_configs:
       - access_key: "{{prometheus_aws_access_key_dev}}" 
         secret_key: "{{prometheus_aws_secret_key_dev}}"
         region: "eu-central-1"
-        port: 9100 # should be the proxy 
-    relabel_configs: # Change the host to the proxy host with relabeling
+        port: 9100  
+    relabel_configs: &ec2_relabeling # Change the host to the proxy host with relabeling
       - source_labels: [__meta_ec2_tag_Environment] # take environment from tags
         target_label: env
       - source_labels: [__address__]
@@ -269,38 +269,9 @@ scrape_configs:
       - access_key: "{{prometheus_aws_access_key_prod}}" 
         secret_key: "{{prometheus_aws_secret_key_prod}}"
         region: "eu-central-1"
-        port: 9100 # should be the proxy 
+        port: 9100  
     relabel_configs: # Change the host to the proxy host with relabeling
-      - source_labels: [__meta_ec2_tag_Environment] # take environment from tags
-        target_label: env
-      - source_labels: [__address__]
-        regex: "([0-9\\.]+):([0-9]+)" # <ip>:<port>"
-        replacement: "$1"
-        target_label: "ec2_host"
-        action: "replace"
-      - source_labels: [__address__]
-        regex: "([0-9\\.]+):([0-9]+)" # <ip>:<port>
-        replacement: "{{clickhouse_proxy_host}}:9200/${1}/${2}/metrics"
-        target_label: "__proxy_host"
-        action: "replace"
-      - source_labels: [__proxy_host, env]
-        separator: ";"
-        regex: "([^;]*)ENV([^;]*);(.*)"
-        replacement: "$1$3$2"
-        target_label: "__proxy_host"
-        action: "replace"
-      - source_labels: [__proxy_host]
-        regex: "([^/]*)/(.*)"
-        replacement: "$1"
-        target_label: "__address__"
-        action: "replace"
-      - source_labels: [__proxy_host]
-        regex: "([^/]*)/(.*)"
-        replacement: "/$2"
-        target_label: "__metrics_path__"
-        action: "replace"
-      - regex: "date_discovered"
-        action: labeldrop
+      *ec2_relabeling
 
   # Scrape tasks in ECS using file based discovery, useful for application level metrics
   - job_name: "ecs-tasks"
@@ -346,4 +317,5 @@ scrape_configs:
         action: "replace"
       - regex: "date_discovered"
         action: labeldrop
+
 ...

--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -225,7 +225,7 @@ scrape_configs:
         secret_key: "{{prometheus_aws_secret_key_dev}}"
         region: "eu-central-1"
         port: 9100  
-        filters:
+        filters: &instance_filters
           - name: instance-state-name
             values: ['running']
     relabel_configs: &ec2_relabeling # Change the host to the proxy host with relabeling
@@ -273,9 +273,8 @@ scrape_configs:
         secret_key: "{{prometheus_aws_secret_key_prod}}"
         region: "eu-central-1"
         port: 9100  
-        filters:
-          - name: instance-state-name
-            values: ['running']
+        filters: 
+          *instance_filters
     relabel_configs: # Change the host to the proxy host with relabeling
       *ec2_relabeling
 

--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -269,6 +269,9 @@ scrape_configs:
         secret_key: "{{prometheus_aws_secret_key_prod}}"
         region: "eu-central-1"
         port: 9100  
+        filters:
+          - name: instance-state-name
+            values: ['running']
     relabel_configs: # Change the host to the proxy host with relabeling
       *ec2_relabeling
 

--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -216,7 +216,7 @@ scrape_configs:
         - backend-hel.ooni.org:444
 
   # EC2 instances monitoring: 
-  - job_name: 'ooni-aws-ec2'
+  - job_name: 'ooni-aws-ec2-dev'
     scrape_interval: 5s
     scheme: https 
     metrics_path: "/metrics" 
@@ -225,6 +225,49 @@ scrape_configs:
     ec2_sd_configs:
       - access_key: "{{prometheus_aws_access_key_dev}}" 
         secret_key: "{{prometheus_aws_secret_key_dev}}"
+        region: "eu-central-1"
+        port: 9100 # should be the proxy 
+    relabel_configs: # Change the host to the proxy host with relabeling
+      - source_labels: [__meta_ec2_tag_Environment] # take environment from tags
+        target_label: env
+      - source_labels: [__address__]
+        regex: "([0-9\\.]+):([0-9]+)" # <ip>:<port>"
+        replacement: "$1"
+        target_label: "ec2_host"
+        action: "replace"
+      - source_labels: [__address__]
+        regex: "([0-9\\.]+):([0-9]+)" # <ip>:<port>
+        replacement: "{{clickhouse_proxy_host}}:9200/${1}/${2}/metrics"
+        target_label: "__proxy_host"
+        action: "replace"
+      - source_labels: [__proxy_host, env]
+        separator: ";"
+        regex: "([^;]*)ENV([^;]*);(.*)"
+        replacement: "$1$3$2"
+        target_label: "__proxy_host"
+        action: "replace"
+      - source_labels: [__proxy_host]
+        regex: "([^/]*)/(.*)"
+        replacement: "$1"
+        target_label: "__address__"
+        action: "replace"
+      - source_labels: [__proxy_host]
+        regex: "([^/]*)/(.*)"
+        replacement: "/$2"
+        target_label: "__metrics_path__"
+        action: "replace"
+      - regex: "date_discovered"
+        action: labeldrop
+
+  - job_name: 'ooni-aws-ec2-prod'
+    scrape_interval: 5s
+    scheme: https 
+    metrics_path: "/metrics" 
+
+    # Node level metrics for cluster nodes
+    ec2_sd_configs:
+      - access_key: "{{prometheus_aws_access_key_prod}}" 
+        secret_key: "{{prometheus_aws_secret_key_prod}}"
         region: "eu-central-1"
         port: 9100 # should be the proxy 
     relabel_configs: # Change the host to the proxy host with relabeling


### PR DESCRIPTION
To finish the prometheus monitoring setup in production we need to add node-level metrics for production hosts.

This PR will add monitoring of EC2 instances in production by adding a new job in prometheus to scrape hosts using the production credentials

This PR closes #209 