### PR TITLE
Add environment tags to EC2 Instances

### DIFF
--- a/tf/environments/prod/.terraform.lock.hcl
+++ b/tf/environments/prod/.terraform.lock.hcl
@@ -73,6 +73,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
 provider "registry.terraform.io/hashicorp/dns" {
   version = "3.4.2"
   hashes = [
+    "h1:2r/hFLnTWnZiIKrxwCrkSH7X2F12fu8BJzuRjHYA45M=",
     "h1:fANvQG0D/XKyj+s+egm66efvr8z2gNKER6UlKfjUxvU=",
     "zh:75e40862402368e23cd298b62519203621cf4891b95e1c863530bf7d8e9614e6",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -812,6 +812,10 @@ module "ansible_controller" {
   key_name  = module.adm_iam_roles.oonidevops_key_name
 
   dns_zone_ooni_io = local.dns_zone_ooni_io
+
+  tags = {
+    Environment = local.environment
+  }
 }
 
 ### Ooni monitoring

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -800,6 +800,9 @@ module "codesigning" {
   subnet_ids         = module.network.vpc_subnet_cloudhsm[*].id
   subnet_cidr_blocks = module.network.vpc_subnet_cloudhsm[*].cidr_block
   key_name           = module.adm_iam_roles.oonidevops_key_name
+  tags = {
+    Environment = local.environment
+  }
 }
 
 ## Ansible controller setup


### PR DESCRIPTION
The Prometheus host will parse the environment from the AWS tags to detect which clickhouse proxy server to use to reach the host. For example, if a machine is deployed in the dev environment, its `Environment` tag will be `dev` and the proxy host used will be `clickhouseproxy.dev.ooni.io`

Some machines in prod don't have the environment set up, so Prometheus will try to reach them through the nonexistent host `clickhouseproxy..ooni.io` 

This PR adds tags to those machines to ensure that Prometheus is able to find them  
