### PR TITLE
Add tag filtering monitoring

### DIFF
--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -228,6 +228,8 @@ scrape_configs:
         filters: &instance_filters
           - name: instance-state-name
             values: ['running']
+          - name: tag:MonitoringActive
+            values: ['true']
     relabel_configs: &ec2_relabeling # Change the host to the proxy host with relabeling
       - source_labels: [__meta_ec2_tag_Environment] # take environment from tags
         target_label: env

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -803,6 +803,7 @@ module "codesigning" {
   tags = {
     Environment = local.environment
   }
+  monitoring_active = "false"
 }
 
 ## Ansible controller setup
@@ -821,6 +822,8 @@ module "ansible_controller" {
   tags = {
     Environment = local.environment
   }
+
+  monitoring_active = "false"
 }
 
 ### Ooni monitoring

--- a/tf/modules/ansible_controller/main.tf
+++ b/tf/modules/ansible_controller/main.tf
@@ -64,7 +64,7 @@ resource "aws_instance" "ansible_controller" {
 
   vpc_security_group_ids = [aws_security_group.ansible_ctrl_sg.id]
 
-  tags = merge(var.tags, { Name = "ansible-controller" })
+  tags = merge({ Name = "ansible-controller", MonitoringActive = var.monitoring_active}, var.tags)
 }
 
 resource "aws_route53_record" "oonith_service_alias" {

--- a/tf/modules/ansible_controller/variables.tf
+++ b/tf/modules/ansible_controller/variables.tf
@@ -30,3 +30,9 @@ variable "monitoring_sg_ids" {
   default = []
   type = list(string)
 }
+
+variable "monitoring_active" {
+  description = "If the monitoring system should consider the ansible controller machine. Set it to 'true' to activate it, anything else to deactivate it"
+  default = "true"
+  type = string
+}

--- a/tf/modules/cloudhsm/main.tf
+++ b/tf/modules/cloudhsm/main.tf
@@ -58,7 +58,7 @@ resource "aws_instance" "codesign_box" {
                 rm cloudhsm-pkcs11.rpm
                 EOF
 
-  tags = merge(var.tags, { Name = "codesign-box" })
+  tags = merge(var.tags, { Name = "codesign-box" , MonitoringActive = var.monitoring_active})
 
   // NOTE: remove the ignore_changes rule to deploy 
   lifecycle {
@@ -88,6 +88,7 @@ resource "aws_launch_template" "codesign_box_template" {
 
     tags = {
       Name = "codesign-box"
+      MonitoringActive = var.monitoring_active
     }
   }
 

--- a/tf/modules/cloudhsm/variables.tf
+++ b/tf/modules/cloudhsm/variables.tf
@@ -26,3 +26,9 @@ variable "tags" {
   default     = {}
   type        = map(string)
 }
+
+variable "monitoring_active" {
+  description = "If the monitoring system should consider the HSM machine. Set it to 'true' to activate it, anything else to deactivate it"
+  default = "true"
+  type = string
+}

--- a/tf/modules/ec2/main.tf
+++ b/tf/modules/ec2/main.tf
@@ -89,7 +89,7 @@ resource "aws_instance" "ooni_ec2" {
     create_before_destroy = true
   }
 
-  tags = var.tags
+  tags = merge(var.tags, {MonitoringActive = var.monitoring_active})
 }
 
 resource "aws_alb_target_group" "ooni_ec2" {

--- a/tf/modules/ec2/variables.tf
+++ b/tf/modules/ec2/variables.tf
@@ -63,3 +63,9 @@ variable "egress_rules" {
 variable "tg_prefix" {
     description = "target group prefix. Will be prefixed with `oo`, example: bkprx -> oobkprx"
 }
+
+variable "monitoring_active" {
+  description = "If the monitoring system should consider this machine. Set it to 'true' to activate it, anything else to deactivate it"
+  default = "true"
+  type = string
+}

--- a/tf/modules/ecs_cluster/main.tf
+++ b/tf/modules/ecs_cluster/main.tf
@@ -183,7 +183,12 @@ resource "aws_launch_template" "container_host" {
 
   tag_specifications {
     resource_type = "instance"
-    tags          = var.tags
+    tags = merge(
+      {
+        MonitoringActive : var.monitoring_active
+      },
+      var.tags
+    )
   }
 }
 

--- a/tf/modules/ecs_cluster/variables.tf
+++ b/tf/modules/ecs_cluster/variables.tf
@@ -70,3 +70,9 @@ variable "monitoring_sg_ids" {
 variable "node_exporter_port" {
   default = "9100"
 }
+
+variable "monitoring_active" {
+  description = "If the monitoring system should consider cluster machines. Set it to 'true' to activate it, anything else to deactivate it"
+  default = "true"
+  type = string
+}


### PR DESCRIPTION
Sometimes we don't want the monitoring system to monitor all machines. In some cases a machine doesn't need to be monitored but it will, and if it's not properly set it will error and show up as down in Prometheus, causing noise. For example: The Ansible controller machine or the codesign box 

In this PR I add a new tag `MonitoringActive`  to EC2 nodes used in: 
- The EC2 module 
- The ecs_cluster module
- The HSM module
- The ansible controller module

So that Prometheus can focus on monitoring machines with the tag set to true: `MonitoringActive = 'true'` and ignore the rest

closes #215 
