### PR TITLE
Listen to branch passed as argument

### DIFF
--- a/tf/modules/ooniapi_service_deployer/main.tf
+++ b/tf/modules/ooniapi_service_deployer/main.tf
@@ -201,6 +201,13 @@ resource "aws_codepipeline" "ooniapi" {
     aws_codebuild_project.ooniapi
   ]
 
+  trigger {
+    provider_type         = "CodeStarSourceConnection"
+    git_configuration {
+      source_action_name = "Source"
+    }
+  }
+
   stage {
     action {
 


### PR DESCRIPTION
The `aws_codepipeline` configuration we are using to auto-deploy code on pushes to the backend repo is currently listening to pushes to `master` only, disregarding the branch passed as argument in the module, see: https://github.com/ooni/devops/blob/db2c61369d4c957a3b04ed4ee1c7e416a47d4b9e/tf/modules/ooniapi_service_deployer/main.tf#L220

In AWS you usually have to setup the following steps: 
- Trigger
- Source
- Build 
- Deploy

In our case we are not setting up the trigger step, and it seems like the default configuration is to listen to pushes to `master` rather than the branch specified in the source step (which is properly configured in AWS!)

In this PR I add a trigger block for the `aws_codepipeline` resource specifying what branch to listen for push events 

closes #205 