### PR TITLE
chore: add internal ooni bucket to deb repo source

### DIFF
--- a/ansible/deploy-ooni-backend.yml
+++ b/ansible/deploy-ooni-backend.yml
@@ -3,23 +3,23 @@
   hosts: backend-hel.ooni.org
   become: true
   roles:
-    # - role: bootstrap
-      # vars:
-        # admin_group_name: adm
-    # - role: base-backend
-    # - role: nftables
-    # - role: nginx
-      # tags: nginx
-      # vars:
-        # nginx_user: "www-data"
-    # - role: dehydrated
-      # tags: dehydrated
-      # expand: yes
-      # vars: 
-        # ssl_domains:
-          # # with dehydrated the first entry is the cert FQDN
-          # # and the other ones are alternative names
-          # - "backend-hel.ooni.org"
+    - role: bootstrap
+      vars:
+        admin_group_name: adm
+    - role: base-backend
+    - role: nftables
+    - role: nginx
+      tags: nginx
+      vars:
+        nginx_user: "www-data"
+    - role: dehydrated
+      tags: dehydrated
+      expand: yes
+      vars: 
+        ssl_domains:
+          # with dehydrated the first entry is the cert FQDN
+          # and the other ones are alternative names
+          - "backend-hel.ooni.org"
     - role: ooni-backend
       vars: 
         ssl_domain: backend-hel.ooni.org

--- a/ansible/roles/base-backend/templates/sources.list
+++ b/ansible/roles/base-backend/templates/sources.list
@@ -4,3 +4,4 @@
 deb http://deb.debian.org/debian bookworm main contrib non-free-firmware
 deb http://deb.debian.org/debian-security/ bookworm-security main contrib non-free-firmware
 deb http://deb.debian.org/debian bookworm-backports main
+deb [trusted=yes] https://ooni-internal-deb.s3.eu-central-1.amazonaws.com unstable main


### PR DESCRIPTION
This diff adds the internal ooni deb package bucket to the base role to setup api hosts.