### PR TITLE
Use the right host name for ssl domains

### DIFF
--- a/ansible/deploy-clickhouse-proxy.yml
+++ b/ansible/deploy-clickhouse-proxy.yml
@@ -9,8 +9,7 @@
     - role: dehydrated
       vars: 
         ssl_domains: 
-          - clickhouseproxy.dev.ooni.io
-          - clickhouseproxy.prod.ooni.io
+          - "{{ inventory_hostname }}"
     - role: nginx
       tags: nginx
     - role: clickhouse_proxy


### PR DESCRIPTION
Change de dehydrated configuration in the clickhouse proxy to use the right domain in the ssl domain parameter.

It will use `clickhouseproxy.prod.ooni.io` in prod, `clickhouseproxy.dev.ooni.io` in dev