### PR TITLE
Fix circular dependency in clickhouse proxy 

### DIFF
--- a/ansible/deploy-clickhouse-proxy.yml
+++ b/ansible/deploy-clickhouse-proxy.yml
@@ -6,15 +6,12 @@
   become: true
   roles:
     - role: bootstrap
+    - role: nginx
+      tags: nginx
     - role: dehydrated
       vars: 
         ssl_domains: 
           - "{{ inventory_hostname }}"
-    - role: nginx
-      tags: nginx
-    - role: dehydrated
-      vars:
-        ssl_domains: "clickhouseproxy.dev.ooni.io"
         tls_cert_dir: /var/lib/dehydrated/certs
     - role: clickhouse_proxy
       vars: 

--- a/ansible/deploy-clickhouse-proxy.yml
+++ b/ansible/deploy-clickhouse-proxy.yml
@@ -6,8 +6,6 @@
   become: true
   roles:
     - role: bootstrap
-    - role: nginx
-      tags: nginx
     - role: dehydrated
       vars: 
         ssl_domains: 

--- a/ansible/deploy-clickhouse-proxy.yml
+++ b/ansible/deploy-clickhouse-proxy.yml
@@ -12,15 +12,15 @@
           - "{{ inventory_hostname }}"
     - role: nginx
       tags: nginx
+    - role: dehydrated
+      vars:
+        ssl_domains: "clickhouseproxy.dev.ooni.io"
+        tls_cert_dir: /var/lib/dehydrated/certs
     - role: clickhouse_proxy
       vars: 
         clickhouse_url: "clickhouse3.prod.ooni.io"
         clickhouse_port: 9000
         clickhouse_proxy_public_fqdn: "{{ inventory_hostname }}"
-    - role: dehydrated
-      vars:
-        ssl_domains: "clickhouseproxy.dev.ooni.io"
-        tls_cert_dir: /var/lib/dehydrated/certs
     - role: prometheus_node_exporter
       vars:
         node_exporter_port: 9100

--- a/ansible/roles/clickhouse_proxy/tasks/main.yml
+++ b/ansible/roles/clickhouse_proxy/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Flush all handlers now
+  meta: flush_handlers
+
 - name: Allow traffic on port 9000
   tags: clickhouse-proxy
   blockinfile:

--- a/ansible/roles/clickhouse_proxy/tasks/main.yml
+++ b/ansible/roles/clickhouse_proxy/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+# Flushing all handlers ensures that dehydrated and nginx are properly set up before proceeding 
+# with the installation. Check deploy-clickhouse-proxy.yml to see the dehydrated setup
+# 
+# This playbook generates new nginx rules that depends on the certificate file from dehydrated, 
+# so if we restart nginx before dehydrated is properly set up this playbook will crash and 
+# it will require manual intervention. 
+#
+# See: https://github.com/ooni/devops/pull/235#discussion_r2052289154
 - name: Flush all handlers now
   meta: flush_handlers
 

--- a/ansible/roles/dehydrated/handlers/main.yml
+++ b/ansible/roles/dehydrated/handlers/main.yml
@@ -13,3 +13,10 @@
     name: dehydrated
     state: restarted
     enabled: yes
+
+- name: reload nginx and restart dehydrated
+  service: 
+    name: nginx
+    state: reloaded
+  notify:
+    restart dehydrated

--- a/ansible/roles/dehydrated/tasks/main.yml
+++ b/ansible/roles/dehydrated/tasks/main.yml
@@ -42,6 +42,8 @@
     dest: /var/lib/dehydrated/acme-challenges/ooni-acme-canary
     mode: "0644"
     owner: root
+  notify:
+    - reload nginx
 
 - name: Restart nginx
   tags: dehydrated

--- a/ansible/roles/dehydrated/tasks/main.yml
+++ b/ansible/roles/dehydrated/tasks/main.yml
@@ -42,8 +42,10 @@
     dest: /var/lib/dehydrated/acme-challenges/ooni-acme-canary
     mode: "0644"
     owner: root
-  notify:
-    - reload nginx
+
+- name: Restart nginx
+  tags: dehydrated
+  shell: systemctl restart nginx
 
 - name: reload nftables service
   tags: dehydrated

--- a/ansible/roles/dehydrated/tasks/main.yml
+++ b/ansible/roles/dehydrated/tasks/main.yml
@@ -42,12 +42,6 @@
     dest: /var/lib/dehydrated/acme-challenges/ooni-acme-canary
     mode: "0644"
     owner: root
-  notify:
-    - reload nginx
-
-- name: Restart nginx
-  tags: dehydrated
-  shell: systemctl restart nginx
 
 - name: reload nftables service
   tags: dehydrated
@@ -90,5 +84,4 @@
   notify:
     # creates:
     # /var/lib/dehydrated/certs/<name>/chain.pem cert.pem privkey.pem fullchain.pem
-    - restart dehydrated
-    - reload nginx
+    - reload nginx and restart dehydrated

--- a/ansible/roles/dehydrated/tasks/main.yml
+++ b/ansible/roles/dehydrated/tasks/main.yml
@@ -84,4 +84,12 @@
   notify:
     # creates:
     # /var/lib/dehydrated/certs/<name>/chain.pem cert.pem privkey.pem fullchain.pem
+
+    # Note that we need to restart dehydrated ensuring that nginx reloads before dehydrated restarts.
+    # When we first run dehydrated with the tasks above it creates an nginx rule that is required
+    # to pass the ACME challenge. 
+    # If nginx doesn't picks this rule before dehydrated runs again, the ACME challenge will fail
+    # crashing the playbook
+    # 
+    # See: https://github.com/ooni/devops/pull/235#discussion_r2053664605
     - reload nginx and restart dehydrated


### PR DESCRIPTION
This diff will fix some issues related to the clickhouse proxy deployment where sometimes you would get a dehydrated error when trying to deploy it, and the solution involved:
1. Moving out an nginx configuration file related to the proxy server
2. Restarting nginx
3. Restarting dehydrated
4. Moving the nginx configuration back in place
5. Restarting nginx

The error was caused because dehydrated and nginx weren't running in the correct order in the ansible play, and dehydrated required an nginx restart to work properly. 

I fixed the order and added the nginx restart to the dehydrated role

closes #232 

After applying this change, the `deploy-clickhouse-proxy.yml` play should deploy the clickhouse proxy in one go without errors