### PR TITLE
Ignore changes to user data on ec2 machines for redeploy

### DIFF
--- a/tf/modules/ec2/main.tf
+++ b/tf/modules/ec2/main.tf
@@ -87,6 +87,7 @@ resource "aws_instance" "ooni_ec2" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ user_data ]
   }
 
   tags = merge(var.tags, {MonitoringActive = var.monitoring_active})


### PR DESCRIPTION
We noticed that the thing triggering the redeploy was a bad hashing on the user data, probably during compression, leading Terraform to think that the file changed when it didn't. We don't have a solution for this so for now we will just ingore changes to the user data, which is empty for now anyways. 

If you update the user data, you might need to manually redeploy affected machines 

Closes #233