### PR TITLE
Add metrics to ec2 fastpath

### DIFF
--- a/ansible/roles/fastpath/tasks/main.yml
+++ b/ansible/roles/fastpath/tasks/main.yml
@@ -100,11 +100,24 @@
     name: fastpath
     image: ooni/fastpath:v0.87
     state: started
-    published_ports: 
-      - "8472:8472"
+    # use network mode = host to allow traffic from fastpath to the statsd exporter without 
+    # creating a network with redirection rules to match the ports
+    network_mode: host  
+    # published_ports: # unused on network_mode: host
+    #   - "8472:8472"
     volumes:
       - /opt/{{fastpath_user}}/backend/fastpath/fastpath.conf:/etc/ooni/fastpath.conf
       - /var/lib/ooniapi:/var/lib/ooniapi
+
+- name: Ensure the statsd to prometheus exporter is running
+  community.docker.docker_container:
+    name: statsd-exporter
+    image: prom/statsd-exporter:v0.28.0
+    state: started
+    published_ports: 
+      - "9102:9102" # for /metrics
+      - "8125:9125" # for reporting metrics 
+      - "8125:9125/udp"
 
 ### API Uploader set up
 - name: configure api uploader using s3 bucket

--- a/ansible/roles/monitoring_proxy/templates/prometheus-proxy.conf
+++ b/ansible/roles/monitoring_proxy/templates/prometheus-proxy.conf
@@ -1,4 +1,5 @@
 server {
+    resolver 169.254.169.253 valid=300s;
     listen 9200 ssl;
 
     server_name {{ monitoring_proxy_public_fqdn }};

--- a/ansible/roles/monitoring_proxy/templates/prometheus-proxy.conf
+++ b/ansible/roles/monitoring_proxy/templates/prometheus-proxy.conf
@@ -1,4 +1,5 @@
 server {
+    # This is the amazon internal resolver, see: https://docs.aws.amazon.com/vpc/latest/userguide/AmazonDNS-concepts.html
     resolver 169.254.169.253 valid=300s;
     listen 9200 ssl;
 

--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -240,7 +240,7 @@ scrape_configs:
         action: "replace"
       - source_labels: [__address__]
         regex: "([0-9\\.]+):([0-9]+)" # <ip>:<port>
-        replacement: "{{clickhouse_proxy_host}}:9200/${1}/${2}/metrics"
+        replacement: "{{monitoring_proxy_host}}:9200/${1}/${2}/metrics"
         target_label: "__proxy_host"
         action: "replace"
       - source_labels: [__proxy_host, env] # Change ENV substr to value of env, find clickhouse proxy host
@@ -300,7 +300,7 @@ scrape_configs:
       # Store the full adress with path in proxy_host
       - source_labels: [__address__]
         regex: "([0-9\\.]+):([0-9]+)" # <ip>:<port>
-        replacement: "{{clickhouse_proxy_host}}:9200/${1}/${2}/metrics" # proxy.org:9200/<private_ip>/<port>/metrics
+        replacement: "{{monitoring_proxy_host}}:9200/${1}/${2}/metrics" # proxy.org:9200/<private_ip>/<port>/metrics
         target_label: "__proxy_host"
         action: "replace"
       # Change the environment part in proxy host
@@ -324,4 +324,50 @@ scrape_configs:
         action: "replace"
       - regex: "date_discovered"
         action: labeldrop
+
+  - job_name: "fastpath"
+    static_configs:
+    - targets: 
+      - fastpath.dev.ooni.io:9102
+      # - fastpath.prod.ooni.io:9102
+    scrape_interval: 5s
+    scheme: https
+    relabel_configs: # Change the host to the proxy host with relabeling
+      # Store ip in ecs_host
+      - source_labels: [__address__]
+        regex: "([a-z\\.]+):([0-9]+)" # <host>:<port>"
+        replacement: "$1"
+        target_label: "ec2_host"
+        action: "replace"
+      # Extract environment from address
+      - source_labels: [__address__]
+        regex: ".*(dev|prod).*"
+        replacement: "$1"
+        target_label: "env"
+        action: "replace"
+      # Store the full adress with path in proxy_host
+      - source_labels: [__address__]
+        regex: "([a-z\\.]+):([0-9]+)" # <host>:<port>
+        replacement: "{{monitoring_proxy_host}}:9200/${1}/${2}/metrics" # proxy.org:9200/<hostname>/<port>/metrics
+        target_label: "__proxy_host"
+        action: "replace"
+      # Change the environment part in proxy host
+      - source_labels: [__proxy_host, env]
+        separator: ";"
+        regex: "([^;]*)ENV([^;]*);(.*)" # __proxy_host;env
+        replacement: "$1$3$2"
+        target_label: "__proxy_host"
+        action: "replace"
+      # Change the address where to send the scrape request to
+      - source_labels: [__proxy_host]
+        regex: "([^/]*)/(.*)"
+        replacement: "$1"
+        target_label: "__address__"
+        action: "replace"
+      # Change the metrics path to include ip address and /metrics path
+      - source_labels: [__proxy_host]
+        regex: "([^/]*)/(.*)"
+        replacement: "/$2"
+        target_label: "__metrics_path__"
+        action: "replace"
 ...

--- a/ansible/roles/prometheus/vars/main.yml
+++ b/ansible/roles/prometheus/vars/main.yml
@@ -157,4 +157,4 @@ prometheus_aws_access_key_prod: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/se
 prometheus_aws_secret_key_prod: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/secrets/ooni_monitoring/secret_key', profile='oonidevops_user_prod') }}"
 
 # We replace the env from relabeling configs
-clickhouse_proxy_host: "monitoringproxy.ENV.ooni.io"
+monitoring_proxy_host: "monitoringproxy.ENV.ooni.io"

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -621,6 +621,11 @@ module "ooni_fastpath" {
     to_port     = 9100,
     protocol    = "tcp"
     cidr_blocks = ["${module.ooni_monitoring_proxy.aws_instance_private_ip}/32"]
+    }, {
+    from_port   = 9102, # For fastpath metrics
+    to_port     = 9102,
+    protocol    = "tcp"
+    cidr_blocks = ["${module.ooni_monitoring_proxy.aws_instance_private_ip}/32"]
   }]
 
   egress_rules = [{


### PR DESCRIPTION
The EC2 fastpath is using statsd for metrics but we weren't collecting the metrics

I added the following service: https://github.com/prometheus/statsd_exporter as a docker container to translate statsd metrics to prometheus

I also added an entry in the prometheus configuration to scrape metrics from this host 

closes #258 