### PR TITLE
Deploy fastpath prod

### DIFF
--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -615,7 +615,7 @@ module "ooni_fastpath" {
     from_port   = 8472,
     to_port     = 8472,
     protocol    = "tcp",
-    cidr_blocks = module.network.vpc_subnet_private[*].cidr_block,
+    cidr_blocks = concat(module.network.vpc_subnet_private[*].cidr_block, module.network.vpc_subnet_public[*].cidr_block),
     }, {
     from_port   = 9100,
     to_port     = 9100,

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -479,7 +479,7 @@ module "ooni_clickhouse_proxy" {
     from_port   = 9000,
     to_port     = 9000,
     protocol    = "tcp",
-    cidr_blocks = concat(module.network.vpc_subnet_private[*].cidr_block, [format("%s/32", module.ooni_fastpath.aws_instance_private_ip)]),
+    cidr_blocks = concat(module.network.vpc_subnet_private[*].cidr_block, ["${module.ooni_fastpath.aws_instance_private_ip}/32", "${module.ooni_fastpath.aws_instance_public_ip}/32"]),
     }, {
     // For the prometheus proxy:
     from_port   = 9200,

--- a/tf/modules/ooniapi_frontend/main.tf
+++ b/tf/modules/ooniapi_frontend/main.tf
@@ -173,7 +173,8 @@ resource "aws_lb_listener_rule" "ooniapi_ooniprobe_rule_2" {
   condition {
     path_pattern {
       values = [
-        "/api/v1/test-helpers*"
+        "/api/v1/test-helpers*",
+        "/report*"
       ]
     }
   }


### PR DESCRIPTION
This PR will deploy the fastpath to production WITHOUT changing the current behavior of the API

The `report/*` endpoints will still point to the monolith, meaning that the fastpath in use will be the monolith one

The intention of this PR is deploy the new infra for the AWS Fastpath and test it in the production environment 

