### PR TITLE
Connect measurements to fastpath

### DIFF
--- a/ansible/host_vars/fastpath.dev.ooni.io/vars.yml
+++ b/ansible/host_vars/fastpath.dev.ooni.io/vars.yml
@@ -2,3 +2,4 @@ s3_ooni_open_data_access_key: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/secr
 clickhouse_url: "clickhouse://write:{{ lookup('amazon.aws.aws_ssm', '/oonidevops/secrets/clickhouse_write_password', profile='oonidevops_user_prod') }}@clickhouseproxy.dev.ooni.io/oonitest"
 bucket_name: "ooni-data-eu-fra-test"
 collector_id: "3"
+env: "dev"

--- a/ansible/roles/fastpath/tasks/main.yml
+++ b/ansible/roles/fastpath/tasks/main.yml
@@ -26,6 +26,18 @@
   notify:
    - reload nftables  
 
+# For serving jsonl files
+- name: Allow traffic on port 8475
+  become: true
+  tags: fastpath
+  blockinfile:
+    path: /etc/ooni/nftables/tcp/8475.nft
+    create: yes
+    block: |
+      add rule inet filter input tcp dport 8475 counter accept comment "serve measurement spool"
+  notify:
+   - reload nftables  
+
 # Docker seems to have problems with nftables, so this command will translate all iptables
 # commands to nftables commands
 - name: Update alternatives for iptables 

--- a/ansible/roles/fastpath/tasks/main.yml
+++ b/ansible/roles/fastpath/tasks/main.yml
@@ -83,7 +83,7 @@
   template:
     src: templates/fastpath.conf
     dest: "/opt/{{fastpath_user}}/backend/fastpath/fastpath.conf"
-    mode: 0444
+    mode: "0744"
     owner: "{{fastpath_user}}"
   become: yes
 
@@ -91,7 +91,7 @@
   ansible.builtin.file:
     path: /var/lib/ooniapi
     state: directory
-    mode: '0700'
+    mode: '0755'
     owner: "{{fastpath_user}}"
     group: "{{fastpath_user}}"
 
@@ -105,6 +105,18 @@
     volumes:
       - /opt/{{fastpath_user}}/backend/fastpath/fastpath.conf:/etc/ooni/fastpath.conf
       - /var/lib/ooniapi:/var/lib/ooniapi
+
+### Serve jsonl from spool dir for oonimeasurements 
+- name: Add nginx config file for serving spool dir measurements
+  tags: fastpath
+  template:
+    src: templates/02-spool-dir.conf
+    dest: /etc/nginx/sites-enabled/02-spool-dir.conf
+    mode: "0444"
+    owner: nginx
+  become: yes
+  notify: 
+    - reload nginx
 
 ### API Uploader set up
 - name: configure api uploader using s3 bucket
@@ -137,7 +149,7 @@
   template:
     src: templates/ooni-api-uploader.service 
     dest: /etc/systemd/system/ooni-api-uploader.service
-    mode: 0644
+    mode: "0644"
     owner: root
 
 - name: Install uploader timer
@@ -145,7 +157,7 @@
   template:
     src: templates/ooni-api-uploader.timer
     dest: /etc/systemd/system/ooni-api-uploader.timer
-    mode: 0644
+    mode: "0644"
     owner: root
 
 - name: Ensure uploader timer runs

--- a/ansible/roles/fastpath/templates/02-spool-dir.conf
+++ b/ansible/roles/fastpath/templates/02-spool-dir.conf
@@ -1,0 +1,14 @@
+# This nginx config will serve spool dir files.
+# This is intended for the oonimeasurements component,
+# which will try to find jsonl measurements in this host
+# if it can't find them in S3
+
+server {
+    listen 8475;
+    server_name fastpath.{{env}}.ooni.io;
+
+    location /measurement_spool/ {
+        alias /var/lib/ooniapi/measurements/incoming/;
+        autoindex off;  # Optional: enables directory listing
+    }
+}

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -617,6 +617,11 @@ module "ooni_fastpath" {
     protocol    = "tcp",
     cidr_blocks = module.network.vpc_subnet_private[*].cidr_block,
     }, {
+    from_port   = 8475, # for serving jsonl files
+    to_port     = 8475,
+    protocol    = "tcp",
+    cidr_blocks = module.network.vpc_subnet_private[*].cidr_block,
+    }, {
     from_port   = 80,
     to_port     = 80,
     protocol    = "tcp",
@@ -882,6 +887,10 @@ module "ooniapi_oonimeasurements" {
     JWT_ENCRYPTION_KEY          = data.aws_ssm_parameter.jwt_secret.arn
     PROMETHEUS_METRICS_PASSWORD = data.aws_ssm_parameter.prometheus_metrics_password.arn
     CLICKHOUSE_URL              = data.aws_ssm_parameter.clickhouse_readonly_url.arn
+  }
+
+  task_environment = {
+    OTHER_COLLECTORS            = jsonencode(["fastpath.${local.environment}.ooni.io:8475"]) # it has to be a json-compliant array
   }
 
   ooniapi_service_security_groups = [

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -479,7 +479,7 @@ module "ooni_clickhouse_proxy" {
     from_port   = 9000,
     to_port     = 9000,
     protocol    = "tcp",
-    cidr_blocks = concat(module.network.vpc_subnet_private[*].cidr_block, [format("%s/32", module.ooni_fastpath.aws_instance_private_ip)]),
+    cidr_blocks = concat(module.network.vpc_subnet_private[*].cidr_block, ["${module.ooni_fastpath.aws_instance_private_ip}/32", "${module.ooni_fastpath.aws_instance_public_ip}/32"]),
     }, {
     // For the prometheus proxy:
     from_port   = 9200,
@@ -616,6 +616,11 @@ module "ooni_fastpath" {
     to_port     = 8472,
     protocol    = "tcp",
     cidr_blocks = module.network.vpc_subnet_private[*].cidr_block,
+    }, {
+    from_port   = 80,
+    to_port     = 80,
+    protocol    = "tcp",
+    cidr_blocks = ["0.0.0.0/0"], # for dehydrated 
     }, {
     from_port   = 9100,
     to_port     = 9100,


### PR DESCRIPTION
This PR will connect the measurements component to the EC2 fastpath machine

In order to serve measurements in real time, the oonimeasurements component should have access to the fastpath spool dir. However, since it's deployed as an ECS service, it doesn't share the same disk as the fastpath

The oonimeasurement component workarounds this by requesting the measurement from a collector with a request, see: 
https://github.com/ooni/backend/blob/7031099070142806e64b96878816110082d31708/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py#L155

So this PR will add an nginx rule to the fastpath to allow access to the spool dir disk for the oonimeasurements component. It will also provide all the necessary access rules 