### PR TITLE
Add base url for dev environment

### DIFF
--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -879,6 +879,10 @@ module "ooniapi_oonimeasurements" {
     CLICKHOUSE_URL              = data.aws_ssm_parameter.clickhouse_readonly_url.arn
   }
 
+  task_environment = {
+    BASE_URL = "https://api.${local.environment}.ooni.io"
+  }
+
   ooniapi_service_security_groups = [
     module.ooniapi_cluster.web_security_group_id
   ]


### PR DESCRIPTION
Adds the base url for the dev environment for oonimeasurements to fix: https://github.com/ooni/backend/issues/979 

closes https://github.com/ooni/backend/issues/979