### PR TITLE
Fix bad alerting names

### DIFF
--- a/ansible/roles/prometheus/files/alert_rules.yml
+++ b/ansible/roles/prometheus/files/alert_rules.yml
@@ -10,7 +10,7 @@ groups:
   # including http scraping failure
   - alert: InstanceDown
     expr: up != 1
-    for: 1m # TODO set back to 5m when we finish testing
+    for: 5m
     annotations:
       summary: '{{ $labels.instance }} {{if $labels.ec2_host}} ({{$labels.ec2_host}}) {{end}} is not `up`'
 


### PR DESCRIPTION
This PR will improve slack alerts by adding the ip address of the broken machine to the slack message 

closes #274 