### PR TITLE
feat: vertically scale cluster machine; reduce overall ec2 count

### DIFF
--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -933,7 +933,7 @@ module "ooniapi_oonimeasurements_deployer" {
 module "ooniapi_oonimeasurements" {
   source = "../../modules/ooniapi_service"
 
-  task_memory = 256
+  task_memory = 512
 
   first_run = true
   vpc_id    = module.network.vpc_id
@@ -946,7 +946,7 @@ module "ooniapi_oonimeasurements" {
   ecs_cluster_id           = module.oonitier1plus_cluster.cluster_id
   # ecs_cluster_id           = module.ooniapi_cluster.cluster_id
 
-  service_desired_count = 8
+  service_desired_count = 4
 
   task_secrets = {
     POSTGRESQL_URL              = data.aws_ssm_parameter.oonipg_url.arn


### PR DESCRIPTION
We experienced an increase in the avg INSERT query latency during high measurement volume after scaling the ecs cluster to include more machines. This could be due to the db being a bottleneck in terms of the number of client machines in the cluster. To this end, this diff reduces the number of machines and spins up larger ones instead so the total count of machines stays low. 

<img width="1688" height="798" alt="Screenshot 2025-11-19 at 22 00 41" src="https://github.com/user-attachments/assets/fb525aca-a965-4e57-b998-4c783f7ca8f6" />
