### PR TITLE
point tor-targets to yourself in backend-hel

### DIFF
--- a/ansible/roles/ooni-backend/templates/nginx-api.conf
+++ b/ansible/roles/ooni-backend/templates/nginx-api.conf
@@ -84,7 +84,7 @@ server {
   }
 
   # Selectively route test-list/urls to the API
-  location ~^/api/v1/test-list/urls {
+  location ~^/api/v1/test-list/(urls|tor-targets) {
       proxy_pass http://127.0.0.1:8000;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
The nginx configuration in `backend-hel` was redirecting the request to `backend-fsn`

Since both hosts had different encryption keys the request was failing 

Changing the nginx configuration file fixed this issue

closes #289 