### PR TITLE
Add access for dillon (Voidly)

### DIFF
--- a/ansible/host_vars/notebook1.htz-fsn.prod.ooni.nu
+++ b/ansible/host_vars/notebook1.htz-fsn.prod.ooni.nu
@@ -110,6 +110,11 @@ ssh_users:
     comment: Toomore Chiang
     keys:
       - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHNIq5cvGr998xyW1uylgzLvD4JQ6/9SOds2LZ5Jbm9R toomore@ocf.tw"
+  dillon:
+    login: dillon
+    comment: Dillon (Voidly)
+    keys:
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKQztdHIbaVzZww+5fJyIjIwCYY7FVT/zCrVnd8yYJWO info@voidly.ai"
   imap:
     login: imap
     comment: iMAP partners (only for training by Siti/Sinar Project)
@@ -117,7 +122,7 @@ ssh_users:
       - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGXhLUbrRculj4wl4jxupwVBZhTUMhV6JtceRy0d6dvl siti.nurliza@sinarproject.org"
 
 admin_usernames: [ art, agrabeli, majakomel, mehul, norbel, luis ]
-non_admin_usernames: [ain, siti, ingrid, joss, vasilis, michael, benginoe, felixhoffmnn, snourin, agix, julia-blues, jonath8, johnbauer, toomore, lex, imap, sloncocs]
+non_admin_usernames: [ain, siti, ingrid, joss, vasilis, michael, benginoe, felixhoffmnn, snourin, agix, julia-blues, jonath8, johnbauer, toomore, dillon, lex, imap, sloncocs]
 jupyterhub_allowed_users: "{{ ssh_users }}"
 admin_group_name: admin
 


### PR DESCRIPTION
### Access Request

**Who:** Dillon, Developer at Voidly
**Affiliation:** https://voidly.ai  
**Contact:** info@voidly.ai

**Research Question:** Building real-time global censorship monitoring showing ISP-level blocking patterns across 195 countries for intelligent anti-censorship.

**What I need:** Direct database access to OONI measurements for faster ISP-level analysis (probe_asn data) and better domain blocking pattern detection.

**Current usage:** Public API (respectful, rate-limited)  
**Duration:** Ongoing open-source anti-censorship project