### PR TITLE
Mention ansible ssh_users role which disables root login

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -123,7 +123,9 @@ individual accounts and lock out the root user.
 When running the entire runbook ansible might try to run it as root.
 This can be avoided by selecting only the required tags using `-t <tagname>`.
 
-Ideally the root user should be disabled after succesfully creating user accounts.
+Ideally the root user should be disabled after succesfully creating user accounts. See role
+[ssh_users](https://github.com/ooni/devops/blob/main/ansible/roles/ssh_users/tasks/main.yml#L62)
+which adds AllowUsers to /etc/sshd_config.d/00-ansible_system_role.conf and disables root login.
 
 #### Roles layout
 


### PR DESCRIPTION
Adds a mention of the ssh_users role which disables ssh root login (and the default user ubuntu); when setting up machines for the first time this behavior can be surprising.