### PR TITLE
Remove mirror diverged alert

### DIFF
--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -203,7 +203,6 @@ scrape_configs:
       - ooni.io:443
       - ooni.torproject.org:443
       - openobservatory.github.io:443
-      - ooni.netlify.app:443
 
 
   # See ansible/roles/ooni-backend/tasks/main.yml for the scraping targets


### PR DESCRIPTION
Remove the Netlify host from monitoring (we're no longer using it) to remove mirror diverged alerts on that host