### PR TITLE
amazon deprecating magnetic volumes

### DIFF
--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -154,7 +154,7 @@ module "oonipg" {
   # With 1GiB of ram you get ~112 connections:
   # 1074000000 / 9531392 = 112.68
   db_instance_class        = "db.t3.micro" # 2GiB => ~224 max_connections
-  db_storage_type          = "standard"
+  db_storage_type          = "gp3"
   db_allocated_storage     = "5"
   db_max_allocated_storage = null
 


### PR DESCRIPTION
You are receiving this notification because you have one or more Amazon RDS databases on magnetic volumes. Amazon RDS will begin deprecating magnetic volumes starting May 1, 2026.

We recommend that you upgrade your magnetic volume storage to the latest SSD based storage volumes (gp3 or io2) before April 29, 2026. After April 29, 2026, Amazon RDS will begin forced migration of magnetic storage volumes to gp3 storage volumes. In addition, the default setting for snapshot restores will be changed to gp3 by June 1, 2026. You will be able to override this default setting with your specific choice.