### PR TITLE
add slackin (slack inviter) resources

### DIFF
--- a/ansible/deploy-tier2.yml
+++ b/ansible/deploy-tier2.yml
@@ -12,6 +12,9 @@
 - name: Include testlists playbook
   ansible.builtin.import_playbook: deploy-testlists.yml
 
+- name: Include slackin playbook
+  ansible.builtin.import_playbook: deploy-slackin.yml
+
 # commented out due to the fact it requires manual config of ~/.ssh/config
 #- name: Setup codesign box
 #  hosts: codesign-box

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -51,3 +51,5 @@ jumphost.dev.ooni.io
 jumphost.prod.ooni.io
 testl.dev.ooni.io
 testl.prod.ooni.io
+slack.dev.ooni.io
+slack.prod.ooni.io

--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -415,4 +415,50 @@ scrape_configs:
         replacement: "/$2"
         target_label: "__metrics_path__"
         action: "replace"
+
+  - job_name: "slackin"
+    static_configs:
+    - targets:
+      - slackin.dev.ooni.io:9102
+      - slackin.prod.ooni.io:9102
+    scrape_interval: 5s
+    scheme: https
+    relabel_configs: # Change the host to the proxy host with relabeling
+      # Store ip in ecs_host
+      - source_labels: [__address__]
+        regex: "([a-z\\.]+):([0-9]+)" # <host>:<port>"
+        replacement: "$1"
+        target_label: "ec2_host"
+        action: "replace"
+      # Extract environment from address
+      - source_labels: [__address__]
+        regex: ".*(dev|prod).*"
+        replacement: "$1"
+        target_label: "env"
+        action: "replace"
+      # Store the full adress with path in proxy_host
+      - source_labels: [__address__]
+        regex: "([a-z\\.]+):([0-9]+)" # <host>:<port>
+        replacement: "{{monitoring_proxy_host}}:9200/${1}/${2}/metrics" # proxy.org:9200/<hostname>/<port>/metrics
+        target_label: "__proxy_host"
+        action: "replace"
+      # Change the environment part in proxy host
+      - source_labels: [__proxy_host, env]
+        separator: ";"
+        regex: "([^;]*)ENV([^;]*);(.*)" # __proxy_host;env
+        replacement: "$1$3$2"
+        target_label: "__proxy_host"
+        action: "replace"
+      # Change the address where to send the scrape request to
+      - source_labels: [__proxy_host]
+        regex: "([^/]*)/(.*)"
+        replacement: "$1"
+        target_label: "__address__"
+        action: "replace"
+      # Change the metrics path to include ip address and /metrics path
+      - source_labels: [__proxy_host]
+        regex: "([^/]*)/(.*)"
+        replacement: "/$2"
+        target_label: "__metrics_path__"
+        action: "replace"
 ...

--- a/ansible/roles/slackin/defaults/main.yml
+++ b/ansible/roles/slackin/defaults/main.yml
@@ -1,0 +1,2 @@
+slackin_org: "openobservatory"
+slackin_token: {{ lookup('amazon.aws.aws_ssm', '/oonidevops/secrets/ansible_slack_token', profile='oonidevops_user_prod') }}

--- a/ansible/roles/slackin/tasks/main.yml
+++ b/ansible/roles/slackin/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Deploy slackin container
+  docker_container:
+    name: slackin
+    image: ooni/slackin
+    restart_policy: unless-stopped
+    state: started
+    published_ports: "80:80"
+    env:
+      SLACKIN_VERSION: latest
+      SLACK_SUBDOMAIN: "{{ slackin_org }}"
+      SLACK_API_TOKEN: "{{ slackin_token }}"

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -1244,6 +1244,94 @@ module "testlists_builder" {
   ecs_cluster_name = module.ooniapi_cluster.cluster_name
 }
 
+### Tier2 slackin service
+module "ooni_slackin" {
+  source = "../../modules/ec2"
+
+  stage = local.environment
+
+  vpc_id              = module.network.vpc_id
+  subnet_id           = module.network.vpc_subnet_public[0].id
+  private_subnet_cidr = module.network.vpc_subnet_private[*].cidr_block
+  dns_zone_ooni_io    = local.dns_zone_ooni_io
+
+  key_name      = module.adm_iam_roles.oonidevops_key_name
+  instance_type = "t3a.nano"
+
+  name = "oonislackin"
+  ingress_rules = [{
+    from_port   = 22,
+    to_port     = 22,
+    protocol    = "tcp",
+    cidr_blocks = ["0.0.0.0/0"],
+    }, {
+    from_port   = 80,
+    to_port     = 80,
+    protocol    = "tcp",
+    cidr_blocks = ["0.0.0.0/0"],
+    }, {
+    // For the prometheus proxy:
+    from_port   = 9200,
+    to_port     = 9200,
+    protocol    = "tcp"
+    cidr_blocks = [for ip in flatten(data.dns_a_record_set.monitoring_host.*.addrs) : "${tostring(ip)}/32"]
+    }, {
+    from_port   = 9100,
+    to_port     = 9100,
+    protocol    = "tcp"
+    cidr_blocks = ["${module.ooni_monitoring_proxy.aws_instance_private_ip}/32"]
+  }]
+
+  egress_rules = [{
+    from_port   = 0,
+    to_port     = 0,
+    protocol    = "-1",
+    cidr_blocks = ["0.0.0.0/0"],
+    }, {
+    from_port        = 0,
+    to_port          = 0,
+    protocol         = "-1",
+    ipv6_cidr_blocks = ["::/0"]
+  }]
+
+  sg_prefix = "oonislack"
+  tg_prefix = "slck"
+
+  disk_size = 20
+
+  tags = merge(
+    local.tags,
+    { Name = "ooni-tier2-slackin" }
+  )
+}
+
+resource "aws_route53_record" "slackin_alias" {
+  zone_id = local.dns_zone_ooni_io
+  name    = "slack.${local.environment}.ooni.io"
+  type    = "CNAME"
+  ttl     = 300
+
+  records = [
+    module.ooni_slackin.aws_instance_public_dns
+  ]
+}
+
+module "slackin_builder" {
+  source      = "../../modules/ooni_docker_build"
+  trigger_tag = ""
+
+  service_name            = "slackin"
+  repo                    = "ooni/slackin-extended"
+  branch_name             = "add_makefile_buildspec"
+  buildspec_path          = "buildspec.yml"
+  trigger_path            = "**"
+  codestar_connection_arn = aws_codestarconnections_connection.oonidevops.arn
+
+  codepipeline_bucket = aws_s3_bucket.ooniapi_codepipeline_bucket.bucket
+
+  ecs_cluster_name = module.ooniapi_cluster.cluster_name
+}
+
 #### OONI Tier0 API Frontend
 
 module "ooniapi_frontend" {
@@ -1259,6 +1347,7 @@ module "ooniapi_frontend" {
   ooniapi_oonifindings_target_group_arn     = module.ooniapi_oonifindings.alb_target_group_id
   ooniapi_oonimeasurements_target_group_arn = module.ooniapi_oonimeasurements.alb_target_group_id
   ooniapi_testlists_target_group_arn        = module.ooniapi_testlists.alb_target_group_id
+  ooni_slackin_target_group_arn             = module.ooni_slackin.alb_target_group_id
 
   ooniapi_service_security_groups = [
     module.ooniapi_cluster.web_security_group_id,
@@ -1286,6 +1375,7 @@ locals {
     "oonimeasurements.${local.environment}.ooni.io" : local.dns_zone_ooni_io,
     "8.th.dev.ooni.io" : local.dns_zone_ooni_io,
     "testlists.${local.environment}.ooni.io" : local.dns_zone_ooni_io,
+    "slackin.${local.environment}.ooni.io" : local.dns_zone_ooni_io,
   }
   ooniapi_frontend_main_domain_name         = "api.${local.environment}.ooni.io"
   ooniapi_frontend_main_domain_name_zone_id = local.dns_zone_ooni_io

--- a/tf/modules/ooniapi_frontend/main.tf
+++ b/tf/modules/ooniapi_frontend/main.tf
@@ -499,3 +499,19 @@ resource "aws_lb_listener_rule" "ooniapi_oonimeasurements_rule_2" {
 //    }
 //  }
 //}
+
+resource "aws_lb_listener_rule" "slack_inviter_rule" {
+  listener_arn = aws_alb_listener.ooniapi_listener_https.arn
+  priority     = 144
+
+  action {
+    type = "forward"
+    target_group_arn = var.ooni_slackin_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["slack.ooni.org"]
+    }
+  }
+}

--- a/tf/modules/ooniapi_frontend/variables.tf
+++ b/tf/modules/ooniapi_frontend/variables.tf
@@ -41,6 +41,10 @@ variable "ooniapi_testlists_target_group_arn" {
   description = "arn for the target group of the testlists service"
 }
 
+variable "ooni_slackin_target_group_arn" {
+  description = "arn for the target group of the slack inviter service"
+}
+
 variable "dns_zone_ooni_io" {
   description = "id of the DNS zone for ooni_io"
 }


### PR DESCRIPTION
this adds a codebuild pipeline to create the docker images from https://github.com/ooni/slackin-extended/ 
it also adds another ec2 instance to host the service. I'm making this a draft PR because we might want to consolidate the other tier2 services as it's resource-inefficient to run an entire instance for just this service.