### PR TITLE
raise oonimeasurements clickhouse user max memory per query

### DIFF
--- a/ansible/group_vars/clickhouse/vars.yml
+++ b/ansible/group_vars/clickhouse/vars.yml
@@ -235,8 +235,8 @@ clickhouse_custom_users:
     networks:
       - "IP '0.0.0.0/0'"
     settings:
-      # 500 MB
-      - "max_memory_usage = 501001000"
+      # 1 GB
+      - "max_memory_usage = 1001001000"
       # 60 seconds
       - "max_execution_time = 30"
     profile:


### PR DESCRIPTION
queries to explorer fail when filtering by category_code:
https://explorer.ooni.org/search?since=2026-03-29&until=2026-04-29&failure=false&category_code=GOVT
```
Server Response

{
  "name": "AxiosError",
  "message": "Network Error",
  "baseURL": "https://api.ooni.org",
  "url": "/api/v1/measurements",
  "params": {
    "category_code": "GOVT",
    "since": "2026-03-29",
    "until": "2026-04-29",
    "failure": false,
    "limit": 50,
    "order": "desc"
  }
}
```
From the service logs:
```
	2026-04-27T14:17:01.787Z
	raise packet.exception
	Link
	2026-04-27T14:17:01.788Z
	clickhouse_driver.errors.ServerException: Code: 241.
	Link
	2026-04-27T14:17:01.788Z
	DB::Exception: Memory limit (for query) exceeded: would use 481.78 MiB (attempt to allocate chunk of 4207200 bytes), maximum: 477.79 MiB.: (while reading c
	```