### PR TITLE
Add fastpath-urls parameter to ooniprobe and update oonimeasurements

### DIFF
--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -14,6 +14,9 @@ locals {
     Environment = local.environment
     Repository  = "https://github.com/ooni/devops"
   }
+
+  # Hostnames of the fastpath collectors used by the OONI backend services.
+  fastpath_hosts = ["fastpath.${local.environment}.ooni.io"]
 }
 
 ## AWS Setup
@@ -593,6 +596,7 @@ module "ooniapi_ooniprobe" {
 
   task_environment = {
     FASTPATH_URL          = "http://fastpath.${local.environment}.ooni.io:8472"
+    FASTPATH_URLS         = jsonencode([for h in local.fastpath_hosts : "http://${h}:8472"])
     FAILED_REPORTS_BUCKET = aws_s3_bucket.ooniprobe_failed_reports.bucket
     COLLECTOR_ID          = 3 # use a different one in prod
     CONFIG_BUCKET         = aws_s3_bucket.ooni_private_config_bucket.bucket
@@ -1145,7 +1149,7 @@ module "ooniapi_oonimeasurements" {
 
   task_environment = {
     # it has to be a json-compliant array
-    OTHER_COLLECTORS                = jsonencode(["http://fastpath.${local.environment}.ooni.io:8475", "https://backend-hel.ooni.org"])
+    OTHER_COLLECTORS                = jsonencode([for h in local.fastpath_hosts : "http://${h}:8475"])
     BASE_URL                        = "https://api.${local.environment}.ooni.io"
     S3_BUCKET_NAME                  = "ooni-data-eu-fra-test"
     VALKEY_URL                      = local.ooniapi_valkey_url

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -15,8 +15,10 @@ locals {
     Repository  = "https://github.com/ooni/devops"
   }
 
-  # Hostnames of the fastpath collectors used by the OONI backend services.
-  fastpath_hosts = ["fastpath.${local.environment}.ooni.io"]
+  # Private IPs of fastpath hosts currently active.
+  fastpath_hosts = [
+    module.ooni_fastpath.aws_instance_private_ip
+  ]
 }
 
 ## AWS Setup

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -19,6 +19,12 @@ locals {
     Environment = local.environment
     Repository  = "https://github.com/ooni/devops"
   }
+
+  # Private IPs of fastpath hosts currently active.
+  fastpath_hosts = [
+    module.ooni_fastpath2.aws_instance_private_ip,
+    # module.ooni_fastpath.aws_instance_private_ip,
+  ]
 }
 
 ## AWS Setup
@@ -891,6 +897,7 @@ module "ooniapi_ooniprobe" {
   task_environment = {
     # hardcoded IP for fastpath2.prod.prod.ooni.io
     FASTPATH_URL          = "http://10.0.0.32:8472"
+    FASTPATH_URLS         = jsonencode([for h in local.fastpath_hosts : "http://${h}:8472"])
     FAILED_REPORTS_BUCKET = aws_s3_bucket.ooniprobe_failed_reports.bucket
     COLLECTOR_ID          = 4 # be sure this is different from dev
     CONFIG_BUCKET         = aws_s3_bucket.ooni_private_config_bucket.bucket
@@ -1320,10 +1327,7 @@ module "ooniapi_oonimeasurements" {
 
   task_environment = {
     # it has to be a json-compliant array
-    OTHER_COLLECTORS = jsonencode([
-      "http://fastpath2.${local.environment}.ooni.io:8475",
-      "https://backend-fsn.ooni.org"
-    ])
+    OTHER_COLLECTORS                = jsonencode([for h in local.fastpath_hosts : "http://${h}:8475"])
     BASE_URL                        = "https://api.ooni.io"
     S3_BUCKET_NAME                  = "ooni-data-eu-fra"
     VALKEY_URL                      = local.ooniapi_valkey_url


### PR DESCRIPTION
This is needed to support https://github.com/ooni/backend/pull/1191

Note that the `FASTPATH_URL` parameter is not removed, we need to remove it in the future after merging 

https://github.com/ooni/backend/pull/1191
