### PR TITLE
fix: add custom admin profile to clickhouse users

### DIFF
--- a/ansible/roles/oonidata_clickhouse/tasks/main.yml
+++ b/ansible/roles/oonidata_clickhouse/tasks/main.yml
@@ -1,5 +1,9 @@
 - ansible.builtin.include_role:
     name: idealista.clickhouse_role
+  vars:
+    clickhouse_custom_profiles:
+      admin:
+        readonly: 0
   tags:
     - oonidata
     - clickhouse


### PR DESCRIPTION
This diff adds a custom admin profile to clickhouse `users.xml` server, since we have an admin user entry but no profile for it