### PR TITLE
Ansible manage clickhouse settings profiles

### DIFF
--- a/ansible/group_vars/clickhouse/vars.yml
+++ b/ansible/group_vars/clickhouse/vars.yml
@@ -232,7 +232,7 @@ clickhouse_custom_users:
   - user:
     name: oonimeasurements
     password_type: sha256_hash
-    password: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/secrets/clickhouse_oonimeasurements_password', profile='oonidevops_user_prod') }}"
+    password: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/secrets/clickhouse_oonimeasurements_password', profile='oonidevops_user_prod') | hash('sha256') }}"
     networks:
       - "IP '0.0.0.0/0'"
     settings:

--- a/ansible/group_vars/clickhouse/vars.yml
+++ b/ansible/group_vars/clickhouse/vars.yml
@@ -245,8 +245,8 @@ clickhouse_custom_users:
       - "max_rows_to_read = 5001001000"
       # 5s
       - "timeout_before_checking_execution_speed = 5"
-      # 10 M
-      - "max_result_rows = 11001000"
+      # 50k
+      - "max_result_rows = 51000"
     profile:
       - readonly
     quota: "oonimeasurements"

--- a/ansible/group_vars/clickhouse/vars.yml
+++ b/ansible/group_vars/clickhouse/vars.yml
@@ -239,6 +239,14 @@ clickhouse_custom_users:
       - "max_memory_usage = 501001000"
       # 60 seconds
       - "max_execution_time = 30"
+      # 500 GB
+      - "max_bytes_to_read = 501001001000"
+      # 5 B
+      - "max_rows_to_read = 5001001000"
+      # 5s
+      - "timeout_before_checking_execution_speed = 5"
+      # 10 M
+      - "max_result_rows = 11001000"
     profile:
       - readonly
     quota: "oonimeasurements"

--- a/ansible/group_vars/clickhouse/vars.yml
+++ b/ansible/group_vars/clickhouse/vars.yml
@@ -165,6 +165,7 @@ clickhouse_distributed_ddl:
   cleanup_delay_period: 60
   max_tasks_in_queue: 1000
 
+clickhouse_role_manage_settings_profiles: True
 clickhouse_default_profiles:
   default:
     readonly: 2
@@ -226,12 +227,12 @@ clickhouse_default_users:
     profile: write
     quota: default
 
-clickhouse_role_manage_users: true
+clickhouse_role_manage_users: True
 clickhouse_custom_users:
   - user:
     name: oonimeasurements
     password_type: sha256_password
-    password: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/secrets/clickhouse_oonimeasurements_password', profile='oonidevops_user_prod') }}"
+    password_sha256_hex: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/secrets/clickhouse_oonimeasurements_password', profile='oonidevops_user_prod') | hash('sha256') }}"
     networks:
       - "IP '0.0.0.0/0'"
     settings:
@@ -252,19 +253,19 @@ clickhouse_custom_users:
     quota: "oonimeasurements"
     databases: [ooni]
 
-# TODO: this quota was created by hand since it wasn't working in the idealista playbook
-clickhouse_role_manage_quotas: false
+clickhouse_role_manage_quotas: True
 clickhouse_custom_quotas:
   # quota over a 10 minute window
   - quota:
     name: oonimeasurements
-    settings:
-      - "INTERVAL 10 minute MAX queries = 12000, MAX errors = 1000, MAX execution_time = 1000"
-    to:
-      - oonimeasurements
+    duration: 600
+    queries: 12000
+    errors: 1000
+    result_rows: 0
+    read_rows: 0
+    execution_time: 1000
 
-clickhouse_role_manage_grants: true
-clickhouse_role_manage_roles: true
+clickhouse_role_manage_grants: True
 clickhouse_custom_grants:
 - on:
   databases: [ooni]
@@ -276,6 +277,7 @@ clickhouse_custom_grant_roles:
   - roles: [oonimeasurements]
     to: [oonimeasurements]
 
+clickhouse_role_manage_roles: True
 clickhouse_custom_roles:
   - role:
     name: oonimeasurements

--- a/ansible/group_vars/clickhouse/vars.yml
+++ b/ansible/group_vars/clickhouse/vars.yml
@@ -231,8 +231,8 @@ clickhouse_role_manage_users: True
 clickhouse_custom_users:
   - user:
     name: oonimeasurements
-    password_type: sha256_password
-    password_sha256_hex: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/secrets/clickhouse_oonimeasurements_password', profile='oonidevops_user_prod') | hash('sha256') }}"
+    password_type: sha256_hash
+    password: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/secrets/clickhouse_oonimeasurements_password', profile='oonidevops_user_prod') }}"
     networks:
       - "IP '0.0.0.0/0'"
     settings:

--- a/ansible/group_vars/clickhouse/vars.yml
+++ b/ansible/group_vars/clickhouse/vars.yml
@@ -235,8 +235,8 @@ clickhouse_custom_users:
     networks:
       - "IP '0.0.0.0/0'"
     settings:
-      # 500 MB
-      - "max_memory_usage = 501001000"
+      # 1 GB
+      - "max_memory_usage = 1001001000"
       # 60 seconds
       - "max_execution_time = 30"
     profile:


### PR DESCRIPTION
merge https://github.com/ooni/devops/pull/417 and  https://github.com/ooni/devops/pull/409 and let ansible manage the profiles, settings, and quotas.