### PR TITLE
node_exporter: use dehydrated when use_https is enabled

### DIFF
--- a/ansible/roles/prometheus_node_exporter/tasks/main.yml
+++ b/ansible/roles/prometheus_node_exporter/tasks/main.yml
@@ -5,6 +5,16 @@
     - node_exporter
   when: use_nginx
 
+- ansible.builtin.include_role:
+    name: dehydrated
+  tags:
+    - oonidata
+    - dehydrated
+  vars:
+    ssl_domains:
+      - "{{ inventory_hostname }}"
+  when: use_https
+
 - name: create ooni configuration directory
   ansible.builtin.file:
     path: "/etc/ooni/"


### PR DESCRIPTION
some of our playbooks also specify the dehydrated role - but if it isn't, then no certificate is created and this role would then fail.