### PR TITLE
Add nginx routing through port for clickhouse servers

### DIFF
--- a/ansible/host_vars/clickhouseproxy.dev.ooni.io/vars.yml
+++ b/ansible/host_vars/clickhouseproxy.dev.ooni.io/vars.yml
@@ -1,1 +1,3 @@
 clickhouse_url: "clickhouse3.prod.ooni.io"
+clickhouse_url_1: "clickhouse3.prod.ooni.io"
+clickhouse_url_2: "clickhouse3.prod.ooni.io"

--- a/ansible/host_vars/clickhouseproxy.prod.ooni.io/vars.yml
+++ b/ansible/host_vars/clickhouseproxy.prod.ooni.io/vars.yml
@@ -1,1 +1,3 @@
-clickhouse_url: "clickhouse2.prod.ooni.io"
+clickhouse_url: "clickhouse1.prod.ooni.io"
+clickhouse_url_1: "clickhouse1.prod.ooni.io"
+clickhouse_url_2: "clickhouse2.prod.ooni.io"

--- a/ansible/roles/clickhouse_proxy/defaults/main.yml
+++ b/ansible/roles/clickhouse_proxy/defaults/main.yml
@@ -1,1 +1,4 @@
 tls_cert_dir: /var/lib/dehydrated/certs
+clickhouse_port: 9000
+clickhouse_url_1: "{{ clickhouse_url }}"
+clickhouse_url_2: "{{ clickhouse_url }}"

--- a/ansible/roles/clickhouse_proxy/tasks/main.yml
+++ b/ansible/roles/clickhouse_proxy/tasks/main.yml
@@ -10,15 +10,19 @@
 - name: Flush all handlers now
   meta: flush_handlers
 
-- name: Allow traffic on port 9000
+- name: Allow traffic on ClickHouse proxy ports
   tags: clickhouse-proxy
   blockinfile:
-    path: /etc/ooni/nftables/tcp/9000.nft
+    path: "/etc/ooni/nftables/tcp/{{ item }}.nft"
     create: yes
     block: |
-      add rule inet filter input tcp dport 9000 counter accept comment "clickhouse"
+      add rule inet filter input tcp dport {{ item }} counter accept comment "clickhouse proxy"
+  loop:
+    - 9000
+    - 9001
+    - 9002
   notify:
-    - reload nftables  
+    - reload nftables
 
 - name: Allow traffic on port 9100
   tags: prometheus-proxy

--- a/ansible/roles/clickhouse_proxy/templates/99-stream.conf
+++ b/ansible/roles/clickhouse_proxy/templates/99-stream.conf
@@ -1,12 +1,33 @@
 stream {
-    upstream clickhouse_backend {
+    upstream clickhouse_default {
         server {{ clickhouse_url }}:{{ clickhouse_port }};
     }
 
+    upstream clickhouse_1 {
+        server {{ clickhouse_url_1 }}:{{ clickhouse_port }};
+    }
+
+    upstream clickhouse_2 {
+        server {{ clickhouse_url_2 }}:{{ clickhouse_port }};
+    }
+
+    # Port-based routing on clickhouseproxy.<env>.ooni.io:
+    #   9000 -> clickhouse_url (default)
+    #   9001 -> clickhouse_url_1
+    #   9002 -> clickhouse_url_2
     server {
         listen 9000;
+        proxy_pass clickhouse_default;
+    }
 
-        proxy_pass clickhouse_backend; 
+    server {
+        listen 9001;
+        proxy_pass clickhouse_1;
+    }
+
+    server {
+        listen 9002;
+        proxy_pass clickhouse_2;
     }
 
     error_log /var/log/nginx/error.log;

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -713,7 +713,7 @@ module "ooni_clickhouse_proxy" {
     cidr_blocks = ["0.0.0.0/0"],
     }, {
     from_port = 9000,
-    to_port   = 9000,
+    to_port   = 9002, // for several clickhouse instances
     protocol  = "tcp",
     cidr_blocks = concat(module.network.vpc_subnet_private[*].cidr_block, ["${module.ooni_fastpath.aws_instance_private_ip}/32", "${module.ooni_fastpath.aws_instance_public_ip}/32"],
     ["${module.ooniapi_testlists.aws_instance_private_ip}/32", "${module.ooniapi_testlists.aws_instance_public_ip}/32"]),

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -514,7 +514,7 @@ module "ooni_clickhouse_proxy" {
     cidr_blocks = ["0.0.0.0/0"],
     }, {
     from_port = 9000,
-    to_port   = 9000,
+    to_port   = 9002, // for several clickhouse instances
     protocol  = "tcp",
     cidr_blocks = concat(
       module.network.vpc_subnet_public[*].cidr_block,


### PR DESCRIPTION
This PR will add the ability to route to different clickhouse instances based on the PORT of the clickhouse proxy: 

```
clickhouseproxy.prod.ooni.io:9000 -> data1 (default, preserves current behavior)
clickhouseproxy.prod.ooni.io:9001 -> data1
clickhouseproxy.prod.ooni.io:9002 -> data2
```