### PR TITLE
add ssl_domains and host_vars for data1.htz-fsn.prod.ooni.io

### DIFF
--- a/ansible/host_vars/data1.htz-fsn.prod.ooni.nu
+++ b/ansible/host_vars/data1.htz-fsn.prod.ooni.nu
@@ -1,0 +1,4 @@
+tls_cert_dir: /var/lib/dehydrated/certs
+ssl_domains:
+   - "data1.htz-fsn.prod.ooni.nu"
+   - "airflow.prod.ooni.io"

--- a/ansible/roles/oonidata_airflow/templates/nginx-airflow.j2
+++ b/ansible/roles/oonidata_airflow/templates/nginx-airflow.j2
@@ -10,9 +10,9 @@ server {
 
     include /etc/nginx/ssl_intermediate.conf;
 
-    ssl_certificate {{ tls_cert_dir }}/{{ inventory_hostname }}/fullchain.pem;
-    ssl_certificate_key {{ tls_cert_dir }}/{{ inventory_hostname }}/privkey.pem;
-    ssl_trusted_certificate {{ tls_cert_dir }}/{{ inventory_hostname }}/chain.pem;
+    ssl_certificate {{ tls_cert_dir }}/{{ airflow_public_fqdn }}/fullchain.pem;
+    ssl_certificate_key {{ tls_cert_dir }}/{{ airflow_public_fqdn }}/privkey.pem;
+    ssl_trusted_certificate {{ tls_cert_dir }}/{{ airflow_public_fqdn }}/chain.pem;
 
     server_name {{ airflow_public_fqdn }};
     access_log  /var/log/nginx/{{ airflow_public_fqdn }}.access.log;


### PR DESCRIPTION
deploy-clickhouse.yml included dehydrated which didn't have airflow.prod.ooni.io in  ssl_domains (by default it uses inventory_hostname); adding this in host_vars ensures that includes of this module always obtain all the certificates.