### PR TITLE
add data2 as a clickhouse-keeper

### DIFF
--- a/ansible/group_vars/clickhouse/vars.yml
+++ b/ansible/group_vars/clickhouse/vars.yml
@@ -94,11 +94,11 @@ clickhouse_keeper:
     hostname: clickhouse1.prod.ooni.io
     port: 9234
 
-  #- keeper_server:
-  #  server: data2.htz-fsn.prod.ooni.nu
-  #  id: 2
-  #  hostname: clickhouse2.prod.ooni.io
-  #  port: 9234
+  - keeper_server:
+    server: data2.htz-fsn.prod.ooni.nu
+    id: 2
+    hostname: clickhouse2.prod.ooni.io
+    port: 9234
 
   - keeper_server:
     server: data3.htz-fsn.prod.ooni.nu
@@ -116,9 +116,9 @@ clickhouse_zookeeper:
   - node:
     host: clickhouse1.prod.ooni.io
     port: 9181
-#  - node:
-#    host: clickhouse2.prod.ooni.io
-#    port: 9181
+  - node:
+    host: clickhouse2.prod.ooni.io
+    port: 9181
   - node:
     host: clickhouse3.prod.ooni.io
     port: 9181

--- a/ansible/group_vars/clickhouse/vars.yml
+++ b/ansible/group_vars/clickhouse/vars.yml
@@ -98,7 +98,7 @@ clickhouse_keeper:
 
   - keeper_server:
     server: data2.htz-fsn.prod.ooni.nu
-    id: 2
+    id: 5
     hostname: clickhouse2.prod.ooni.io
     port: 9234
 


### PR DESCRIPTION
Adds data2 as a clickhouse-keeper; in order to deprecate notebook1 as keeper