### PR TITLE
fix oonipg deployment in dev

### DIFF
--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -160,7 +160,7 @@ module "oonipg" {
   # 1074000000 / 9531392 = 112.68
   db_instance_class        = "db.t4g.micro" # 2GiB => ~224 max_connections
   db_storage_type          = "gp3"
-  db_allocated_storage     = "5"
+  db_allocated_storage     = "20"
   db_max_allocated_storage = null
 
   allow_cidr_blocks = [

--- a/tf/environments/dev/main.tf
+++ b/tf/environments/dev/main.tf
@@ -159,7 +159,7 @@ module "oonipg" {
   # With 1GiB of ram you get ~112 connections:
   # 1074000000 / 9531392 = 112.68
   db_instance_class        = "db.t4g.micro" # 2GiB => ~224 max_connections
-  db_storage_type          = "standard"
+  db_storage_type          = "gp3"
   db_allocated_storage     = "5"
   db_max_allocated_storage = null
 

--- a/tf/modules/postgresql/variables.tf
+++ b/tf/modules/postgresql/variables.tf
@@ -40,7 +40,7 @@ variable "db_allocated_storage" {
 }
 
 variable "db_storage_type" {
-  default = "standard"
+  default = "gp3"
 }
 
 variable "db_max_allocated_storage" {
@@ -48,7 +48,7 @@ variable "db_max_allocated_storage" {
 }
 
 variable "db_engine_version" {
-  default = "16.8"
+  default = "16.13"
 }
 
 variable "db_parameter_group" {


### PR DESCRIPTION
this also updates the default module version (used in dev) and sync's the pg storage size to the current deployment. I'm not sure how this got increased to 20gb but using a smaller value fails to apply.

deployed on dev instance.