### PR TITLE
add fastpath instance for reuploading reports

### DIFF
--- a/ansible/deploy-fastpath.yml
+++ b/ansible/deploy-fastpath.yml
@@ -4,6 +4,7 @@
     - fastpath.dev.ooni.io
     - fastpath.prod.ooni.io
     - fastpath2.prod.ooni.io
+    - reuploaderfastpath.prod.ooni.io
   become: true
   roles:
     - role: bootstrap

--- a/ansible/host_vars/reuploaderfastpath.prod.ooni.io/vars.yml
+++ b/ansible/host_vars/reuploaderfastpath.prod.ooni.io/vars.yml
@@ -1,0 +1,6 @@
+s3_ooni_open_data_access_key: "{{ lookup('amazon.aws.aws_ssm', '/oonidevops/secrets/s3_ooni_open_data_access_key', profile='oonidevops_user_prod') }}"
+clickhouse_url: "clickhouse://write:{{ lookup('amazon.aws.aws_ssm', '/oonidevops/secrets/clickhouse_write_password', profile='oonidevops_user_prod') }}@data1.htz-fsn.prod.ooni.nu/ooni"
+bucket_name: "ooni-data-eu-fra"
+# COLLECTOR ID SHOULD BE DIFFERENT BETWEEN EACH FASTPATH INSTANCE
+collector_id: "5"
+env: "prod"

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -49,6 +49,7 @@ openvpn2.htz-fsn.prod.ooni.nu
 fastpath.dev.ooni.io
 fastpath.prod.ooni.io
 fastpath2.prod.ooni.io
+reuploaderfastpath.prod.ooni.io
 anonc.dev.ooni.io
 jumphost.dev.ooni.io
 jumphost.prod.ooni.io

--- a/ansible/roles/prometheus/templates/prometheus.yml
+++ b/ansible/roles/prometheus/templates/prometheus.yml
@@ -346,6 +346,7 @@ scrape_configs:
       - fastpath.dev.ooni.io:9102
       - fastpath.prod.ooni.io:9102
       - fastpath2.prod.ooni.io:9102
+      - reuploaderfastpath.prod.ooni.io:9102
     scrape_interval: 5s
     scheme: https
     relabel_configs: # Change the host to the proxy host with relabeling

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -983,17 +983,17 @@ module "ooni_fastpath2" {
 module "ooni_reuploader_fastpath" {
   source = "../../modules/ooni_fastpath"
 
-  stage = local.environment
+  name = "reuploaderfastpath"
+  env  = local.environment
 
   vpc_id              = module.network.vpc_id
   subnet_id           = module.network.vpc_subnet_public[0].id
   private_subnet_cidr = module.network.vpc_subnet_private[*].cidr_block
+  public_subnet_cidr  = module.network.vpc_subnet_public[*].cidr_block
   dns_zone_ooni_io    = local.dns_zone_ooni_io
 
   key_name      = module.adm_iam_roles.oonidevops_key_name
   instance_type = "t3a.small"
-
-  name = "reuploaderfastpath"
 
   sg_prefix = "oonirefp"
   tg_prefix = "refp"

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -1033,6 +1033,83 @@ resource "aws_route53_record" "fastpath2_alias" {
   ]
 }
 
+# fastpath instance for reuploading reports to from the failed-measurements bucket
+module "ooni_reuploader_fastpath" {
+  source = "../../modules/ec2"
+
+  stage = local.environment
+
+  vpc_id              = module.network.vpc_id
+  subnet_id           = module.network.vpc_subnet_public[0].id
+  private_subnet_cidr = module.network.vpc_subnet_private[*].cidr_block
+  dns_zone_ooni_io    = local.dns_zone_ooni_io
+
+  key_name      = module.adm_iam_roles.oonidevops_key_name
+  instance_type = "t3a.small"
+
+  name = "oonireuploaderfastpath"
+  ingress_rules = [{
+    from_port   = 22,
+    to_port     = 22,
+    protocol    = "tcp",
+    cidr_blocks = ["0.0.0.0/0"],
+    }, {
+    from_port   = 8472,
+    to_port     = 8472,
+    protocol    = "tcp",
+    cidr_blocks = concat(module.network.vpc_subnet_private[*].cidr_block, module.network.vpc_subnet_public[*].cidr_block),
+    }, {
+    from_port   = 8479,
+    to_port     = 8479,
+    protocol    = "tcp",
+    cidr_blocks = concat(module.network.vpc_subnet_private[*].cidr_block, module.network.vpc_subnet_public[*].cidr_block),
+    }, {
+    from_port   = 9100,
+    to_port     = 9100,
+    protocol    = "tcp"
+    cidr_blocks = ["${module.ooni_monitoring_proxy.aws_instance_private_ip}/32"]
+    }, {
+    from_port   = 9102, # For fastpath metrics
+    to_port     = 9102,
+    protocol    = "tcp"
+    cidr_blocks = ["${module.ooni_monitoring_proxy.aws_instance_private_ip}/32", "${module.ooni_monitoring_proxy.aws_instance_public_ip}/32"]
+  }]
+
+  egress_rules = [{
+    from_port   = 0,
+    to_port     = 0,
+    protocol    = "-1",
+    cidr_blocks = ["0.0.0.0/0"],
+    }, {
+    from_port        = 0,
+    to_port          = 0,
+    protocol         = "-1",
+    ipv6_cidr_blocks = ["::/0"],
+  }]
+
+  sg_prefix = "oonirefp"
+  tg_prefix = "refp"
+
+  disk_size = 150
+
+  tags = merge(
+    local.tags,
+    { Name = "ooni-tier0-reuploader-fastpath" }
+  )
+}
+
+resource "aws_route53_record" "reuploader_fastpath" {
+  zone_id = local.dns_zone_ooni_io
+  name    = "reuploaderfastpath.${local.environment}.ooni.io"
+  type    = "CNAME"
+  ttl     = 300
+
+  records = [
+    module.ooni_reuploader_fastpath.aws_instance_public_dns
+  ]
+}
+
+
 module "fastpath_builder" {
   source      = "../../modules/ooni_docker_build"
   trigger_tag = ""

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -1037,7 +1037,7 @@ resource "aws_route53_record" "fastpath2_alias" {
 
 # fastpath instance for reuploading reports to from the failed-measurements bucket
 module "ooni_reuploader_fastpath" {
-  source = "../../modules/ec2"
+  source = "../../modules/ooni_fastpath"
 
   stage = local.environment
 
@@ -1049,55 +1049,17 @@ module "ooni_reuploader_fastpath" {
   key_name      = module.adm_iam_roles.oonidevops_key_name
   instance_type = "t3a.small"
 
-  name = "oonireuploaderfastpath"
-  ingress_rules = [{
-    from_port   = 22,
-    to_port     = 22,
-    protocol    = "tcp",
-    cidr_blocks = ["0.0.0.0/0"],
-    }, {
-    from_port   = 8472,
-    to_port     = 8472,
-    protocol    = "tcp",
-    cidr_blocks = concat(module.network.vpc_subnet_private[*].cidr_block, module.network.vpc_subnet_public[*].cidr_block),
-    }, {
-    from_port   = 8479,
-    to_port     = 8479,
-    protocol    = "tcp",
-    cidr_blocks = concat(module.network.vpc_subnet_private[*].cidr_block, module.network.vpc_subnet_public[*].cidr_block),
-    }, {
-    from_port   = 9100,
-    to_port     = 9100,
-    protocol    = "tcp"
-    cidr_blocks = ["${module.ooni_monitoring_proxy.aws_instance_private_ip}/32"]
-    }, {
-    from_port   = 9102, # For fastpath metrics
-    to_port     = 9102,
-    protocol    = "tcp"
-    cidr_blocks = ["${module.ooni_monitoring_proxy.aws_instance_private_ip}/32", "${module.ooni_monitoring_proxy.aws_instance_public_ip}/32"]
-  }]
-
-  egress_rules = [{
-    from_port   = 0,
-    to_port     = 0,
-    protocol    = "-1",
-    cidr_blocks = ["0.0.0.0/0"],
-    }, {
-    from_port        = 0,
-    to_port          = 0,
-    protocol         = "-1",
-    ipv6_cidr_blocks = ["::/0"],
-  }]
+  name = "reuploaderfastpath"
 
   sg_prefix = "oonirefp"
   tg_prefix = "refp"
 
-  disk_size = 150
+  disk_size = 20
 
-  tags = merge(
-    local.tags,
-    { Name = "ooni-tier0-reuploader-fastpath" }
-  )
+  monitoring_proxy_private_ip = module.ooni_monitoring_proxy.aws_instance_private_ip
+  monitoring_proxy_public_ip  = module.ooni_monitoring_proxy.aws_instance_public_ip
+
+  tags = local.tags
 }
 
 resource "aws_route53_record" "reuploader_fastpath" {

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -1006,18 +1006,6 @@ module "ooni_reuploader_fastpath" {
   tags = local.tags
 }
 
-resource "aws_route53_record" "reuploader_fastpath" {
-  zone_id = local.dns_zone_ooni_io
-  name    = "reuploaderfastpath.${local.environment}.ooni.io"
-  type    = "CNAME"
-  ttl     = 300
-
-  records = [
-    module.ooni_reuploader_fastpath.aws_instance_public_dns
-  ]
-}
-
-
 module "fastpath_builder" {
   source      = "../../modules/ooni_docker_build"
   trigger_tag = ""

--- a/tf/environments/prod/main.tf
+++ b/tf/environments/prod/main.tf
@@ -523,6 +523,8 @@ module "ooni_clickhouse_proxy" {
       "${module.ooni_fastpath.aws_instance_public_ip}/32"],
       ["${module.ooni_fastpath2.aws_instance_private_ip}/32",
       "${module.ooni_fastpath2.aws_instance_public_ip}/32"],
+      ["${module.ooni_reuploader_fastpath.aws_instance_private_ip}/32",
+      "${module.ooni_reuploader_fastpath.aws_instance_public_ip}/32"],
       ["${module.ooniapi_testlists.aws_instance_private_ip}/32",
       "${module.ooniapi_testlists.aws_instance_public_ip}/32"],
     ),


### PR DESCRIPTION
Adds another fastpath+s3 uploader instance for failed reports to be resubmitted to.
https://github.com/ooni/devops/issues/398