### PR TITLE
prometheus_node_exporter: don't override host_vars ssl_domains

### DIFF
--- a/ansible/deploy-clickhouse.yml
+++ b/ansible/deploy-clickhouse.yml
@@ -6,8 +6,8 @@
     - data2.htz-fsn.prod.ooni.nu
     - data3.htz-fsn.prod.ooni.nu
   become: true
-  tags:
-    - clickhouse
   roles:
-    - prometheus_node_exporter
-    - oonidata_clickhouse
+    - role: prometheus_node_exporter
+      tags: [node_exporter]
+    - role: oonidata_clickhouse
+      tags: [clickhouse]

--- a/ansible/roles/prometheus_node_exporter/tasks/main.yml
+++ b/ansible/roles/prometheus_node_exporter/tasks/main.yml
@@ -11,7 +11,7 @@
     - oonidata
     - dehydrated
   vars:
-    ssl_domains: "{{ ssl_domains | default([inventory_hostname]) }}"
+    ssl_domains: "{{ hostvars[inventory_hostname].ssl_domains | default([inventory_hostname]) }}"
   when: use_https
 
 - name: create ooni configuration directory

--- a/ansible/roles/prometheus_node_exporter/tasks/main.yml
+++ b/ansible/roles/prometheus_node_exporter/tasks/main.yml
@@ -11,8 +11,7 @@
     - oonidata
     - dehydrated
   vars:
-    ssl_domains:
-      - "{{ inventory_hostname }}"
+    ssl_domains: "{{ ssl_domains | default([inventory_hostname]) }}"
   when: use_https
 
 - name: create ooni configuration directory


### PR DESCRIPTION
only set ssl_domains to inventory_hostname if ssl_domains is not defined