### PR TITLE
override clickhouse_role_manage_grants on notebook

### DIFF
--- a/ansible/host_vars/notebook.ooni.org
+++ b/ansible/host_vars/notebook.ooni.org
@@ -145,6 +145,7 @@ clickhouse_listen_hosts:
 
 # this only applies to SQL managed users
 clickhouse_role_manage_users: false
+clickhouse_role_manage_grants: false
 # these are handled via config files
 clickhouse_default_users:
   - user:


### PR DESCRIPTION
as notebook doesn't have the sql-backed users, the grants shouldn't be assigned either because that makes the ansible role puke